### PR TITLE
fix: create global constants for validator's max min value

### DIFF
--- a/backend/src/constants/database.ts
+++ b/backend/src/constants/database.ts
@@ -3,15 +3,8 @@ export enum Mode {
   BASIC = "BASIC",
 }
 
-export enum AgeGroup {
-  CHILD = "CHILD",
-  TEEN = "TEEN",
-  ADULT = "ADULT",
-  SENIOR = "SENIOR",
-}
-
 export enum MediaType {
-  IMAGE = "IMAGE",
+  PHOTO = "PHOTO",
   VIDEO = "VIDEO",
   AUDIO = "AUDIO",
 }
@@ -33,3 +26,9 @@ export enum InvitationStatus {
   PENDING = "PENDING",
   ACCEPTED = "ACCEPTED",
 }
+
+export const TEXT_MAX_LIMIT = 500;
+export const NAME_MAX_LIMIT = 100;
+export const DEVICE_TOKEN_MAX_LIMIT = 152;
+export const MIN_LIMIT = 1;
+export const NOTIFICATION_BODY_MAX_LIMIT = 300;

--- a/backend/src/entities/groups/validator.ts
+++ b/backend/src/entities/groups/validator.ts
@@ -1,3 +1,4 @@
+import { MIN_LIMIT, NAME_MAX_LIMIT, TEXT_MAX_LIMIT } from "../../constants/database";
 import { groupsTable } from "../schema";
 import z from "zod";
 
@@ -8,12 +9,12 @@ export const createGroupValidate = z
   .object({
     name: z
       .string()
-      .min(1, "Name must be at least 1 character long")
-      .max(100, "Name must be at most 100 characters long"),
+      .min(MIN_LIMIT, `Name must be at least ${MIN_LIMIT} character long`)
+      .max(NAME_MAX_LIMIT, `Name must be at most ${NAME_MAX_LIMIT} characters long`),
     description: z
       .string()
-      .min(1, "Description must be at least 1 character long")
-      .max(500, "Description must be at most 500 characters long")
+      .min(MIN_LIMIT, `Description must be at least ${MIN_LIMIT} character long`)
+      .max(TEXT_MAX_LIMIT, `Description must be at most ${TEXT_MAX_LIMIT} characters long`)
       .optional(),
   })
   .passthrough();

--- a/backend/src/entities/schema.ts
+++ b/backend/src/entities/schema.ts
@@ -1,5 +1,11 @@
+import {
+  TEXT_MAX_LIMIT,
+  DEVICE_TOKEN_MAX_LIMIT,
+  NOTIFICATION_BODY_MAX_LIMIT,
+} from "./../constants/database";
 import { timestamp, uuid, pgEnum, pgTable, varchar, boolean } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
+import { NAME_MAX_LIMIT } from "../constants/database";
 
 export const userModeEnum = pgEnum("mode", ["BASIC", "ADVANCED"]);
 export const postMediaEnum = pgEnum("mediaType", ["VIDEO", "PHOTO"]);
@@ -15,8 +21,8 @@ export const invitationStatusEnum = pgEnum("status", ["PENDING", "ACCEPTED"]);
 
 export const usersTable = pgTable("users", {
   id: uuid().primaryKey().defaultRandom(),
-  name: varchar({ length: 100 }).notNull(),
-  username: varchar({ length: 100 }).notNull().unique(),
+  name: varchar({ length: NAME_MAX_LIMIT }).notNull(),
+  username: varchar({ length: NAME_MAX_LIMIT }).notNull().unique(),
   mode: userModeEnum().notNull().default("BASIC"),
   profilePhoto: varchar(),
   notificationsEnabled: boolean().notNull().default(true),
@@ -27,13 +33,13 @@ export const devicesTable = pgTable("devices", {
   userId: uuid()
     .notNull()
     .references(() => usersTable.id, { onDelete: "cascade" }),
-  token: varchar({ length: 152 }).notNull(),
+  token: varchar({ length: DEVICE_TOKEN_MAX_LIMIT }).notNull(),
 });
 
 export const groupsTable = pgTable("groups", {
   id: uuid().primaryKey().defaultRandom(),
-  name: varchar({ length: 100 }).notNull(),
-  description: varchar({ length: 500 }),
+  name: varchar({ length: NAME_MAX_LIMIT }).notNull(),
+  description: varchar({ length: TEXT_MAX_LIMIT }),
   managerId: uuid()
     .notNull()
     .references(() => usersTable.id, { onDelete: "cascade" }),
@@ -48,7 +54,7 @@ export const postsTable = pgTable("posts", {
     .notNull()
     .references(() => usersTable.id, { onDelete: "cascade" }),
   createdAt: timestamp().notNull().defaultNow(),
-  caption: varchar({ length: 500 }),
+  caption: varchar({ length: TEXT_MAX_LIMIT }),
 });
 
 export const mediaTable = pgTable("media", {
@@ -89,7 +95,7 @@ export const commentsTable = pgTable("comments", {
   postId: uuid()
     .notNull()
     .references(() => postsTable.id, { onDelete: "cascade" }),
-  content: varchar({ length: 500 }),
+  content: varchar({ length: TEXT_MAX_LIMIT }),
   voiceMemo: varchar(),
 });
 
@@ -107,8 +113,8 @@ export const notificationsTable = pgTable("notifications", {
   commentId: uuid().references(() => commentsTable.id, { onDelete: "cascade" }),
   likeId: uuid().references(() => likesTable.id, { onDelete: "cascade" }),
   invitationId: uuid().references(() => invitationsTable.id, { onDelete: "cascade" }),
-  title: varchar({ length: 100 }).notNull(),
-  description: varchar({ length: 300 }).notNull(),
+  title: varchar({ length: NAME_MAX_LIMIT }).notNull(),
+  description: varchar({ length: NOTIFICATION_BODY_MAX_LIMIT }).notNull(),
 });
 
 export const linksTable = pgTable("links", {

--- a/backend/src/entities/users/validator.ts
+++ b/backend/src/entities/users/validator.ts
@@ -2,19 +2,20 @@ import { usersTable } from "../schema";
 import { createInsertSchema, createUpdateSchema } from "drizzle-zod";
 import z from "zod";
 import { Expo } from "expo-server-sdk";
+import { MIN_LIMIT } from "../../constants/database";
 
 export type CreateUserPayload = typeof usersTable.$inferInsert;
 export type UpdateUserPayload = Partial<typeof usersTable.$inferInsert>;
 export type User = typeof usersTable.$inferSelect;
 
 export const createUserValidate = createInsertSchema(usersTable, {
-  name: (schema) => schema.min(1),
-  username: (schema) => schema.min(1),
+  name: (schema) => schema.min(MIN_LIMIT),
+  username: (schema) => schema.min(MIN_LIMIT),
 }).omit({ id: true });
 
 export const updateUserValidate = createUpdateSchema(usersTable, {
-  name: (schema) => schema.min(1),
-  username: (schema) => schema.min(1),
+  name: (schema) => schema.min(MIN_LIMIT),
+  username: (schema) => schema.min(MIN_LIMIT),
 }).omit({ id: true });
 
 export const expoTokenValidate = z.object({


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, the issue being fixed (if applicable), motivation and context, and anything that we should look out for. -->
- Turn repetitive max and min values in validators and database schema into global constants for single source of truth.
- Remove ageGroup enum because we no longer need it.
- Fix enum for media type to ensure consistency with database enum.

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added necessary tests (unit, integration, etc.) to cover the new functionality or fix.
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation to reflect changes (e.g., README, code comments).
- [x] I have removed any commented-out code, debug statements, or unnecessary console logs.
