### PR TITLE
feat: get all user's posts and groups endpoints

### DIFF
--- a/backend/src/entities/posts/transaction.ts
+++ b/backend/src/entities/posts/transaction.ts
@@ -1,11 +1,6 @@
 import { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { CreatePostPayload, IDPayload, Media, PostWithMedia, UpdatePostPayload } from "./validator";
-import {
-  groupsTable,
-  mediaTable,
-  membersTable,
-  postsTable,
-} from "../schema";
+import { groupsTable, mediaTable, membersTable, postsTable } from "../schema";
 import { eq, and, sql } from "drizzle-orm";
 import { ForbiddenError, NotFoundError } from "../../utilities/errors/app-error";
 

--- a/backend/src/entities/posts/transaction.ts
+++ b/backend/src/entities/posts/transaction.ts
@@ -1,14 +1,12 @@
 import { PostgresJsDatabase } from "drizzle-orm/postgres-js";
-import { CreatePostPayload, IDPayload, PostWithMedia, UpdatePostPayload } from "./validator";
+import { CreatePostPayload, IDPayload, Media, PostWithMedia, UpdatePostPayload } from "./validator";
 import {
-  commentsTable,
   groupsTable,
-  likesTable,
   mediaTable,
   membersTable,
   postsTable,
 } from "../schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { ForbiddenError, NotFoundError } from "../../utilities/errors/app-error";
 
 export interface PostTransaction {
@@ -72,8 +70,22 @@ export class PostTransactionImpl implements PostTransaction {
   }
 
   async getPost(payload: IDPayload): Promise<PostWithMedia | null> {
-    const result = await this.db
-      .select()
+    const [result] = await this.db
+      .select({
+        id: postsTable.id,
+        userId: postsTable.userId,
+        groupId: postsTable.groupId,
+        createdAt: postsTable.createdAt,
+        caption: postsTable.caption,
+        media: sql<Media[]>`array_agg(
+        json_build_object(
+          'id', ${mediaTable.id},
+          'type', ${mediaTable.type},
+          'postId', ${mediaTable.postId},
+          'url', ${mediaTable.url}
+        )
+      )`,
+      })
       .from(postsTable)
       .innerJoin(mediaTable, eq(postsTable.id, mediaTable.postId))
       .innerJoin(groupsTable, eq(postsTable.groupId, groupsTable.id))
@@ -81,20 +93,19 @@ export class PostTransactionImpl implements PostTransaction {
         membersTable,
         and(eq(groupsTable.id, membersTable.groupId), eq(membersTable.userId, payload.userId)),
       )
-      .leftJoin(commentsTable, eq(postsTable.id, commentsTable.postId))
-      .leftJoin(likesTable, eq(postsTable.id, likesTable.postId))
+      .groupBy(
+        postsTable.id,
+        postsTable.userId,
+        postsTable.groupId,
+        postsTable.createdAt,
+        postsTable.caption,
+      )
       .where(eq(postsTable.id, payload.id));
 
-    if (!result[0]) return null;
-
-    const post = result[0].posts;
-    const media = result.map((r) => r.media).filter((m) => m !== null);
+    if (!result) return null;
 
     // TODO: return post with comments and likes later
-    return {
-      ...post,
-      media,
-    };
+    return result;
   }
 
   async updatePost(payload: UpdatePostPayload): Promise<PostWithMedia | null> {

--- a/backend/src/entities/posts/validator.ts
+++ b/backend/src/entities/posts/validator.ts
@@ -43,7 +43,7 @@ export type IDPayload = {
   groupId: string;
 };
 
-type Media = typeof mediaTable.$inferSelect;
+export type Media = typeof mediaTable.$inferSelect;
 type Post = typeof postsTable.$inferSelect;
 
 export type PostWithMedia = Post & {

--- a/backend/src/entities/users/controller.ts
+++ b/backend/src/entities/users/controller.ts
@@ -1,6 +1,11 @@
 import { Context } from "hono";
 import { UserService } from "./service";
-import { createUserValidate, expoTokenValidate, updateUserValidate } from "./validator";
+import {
+  createUserValidate,
+  expoTokenValidate,
+  paginationSchema,
+  updateUserValidate,
+} from "./validator";
 import { parseUUID } from "../../utilities/uuid";
 import { handleAppError } from "../../utilities/errors/app-error";
 import { Status } from "../../constants/http";
@@ -13,6 +18,8 @@ export interface UserController {
   deleteUser(ctx: Context): Promise<DEL_USER>;
   registerDevice(ctx: Context): Promise<DEVICE_RESPONSE>;
   removeDevice(ctx: Context): Promise<DEVICE_RESPONSE>;
+  getPosts(ctx: Context): Promise<Response>;
+  getGroups(ctx: Context): Promise<Response>;
 }
 
 export class UserControllerImpl implements UserController {
@@ -90,5 +97,27 @@ export class UserControllerImpl implements UserController {
       return ctx.json(user, Status.OK);
     };
     return await handleAppError(removeDeviceImpl)(ctx);
+  }
+
+  async getPosts(ctx: Context): Promise<Response> {
+    const getPostsImpl = async () => {
+      const { limit, page } = ctx.req.query();
+      const queryParams = paginationSchema.parse({ limit, page });
+      const userId = ctx.get("userId");
+      const posts = await this.userService.getPosts({ id: userId, ...queryParams });
+      return ctx.json(posts, Status.OK);
+    };
+    return await handleAppError(getPostsImpl)(ctx);
+  }
+
+  async getGroups(ctx: Context): Promise<Response> {
+    const getGroupsImpl = async () => {
+      const { limit, page } = ctx.req.query();
+      const queryParams = paginationSchema.parse({ limit, page });
+      const userId = ctx.get("userId");
+      const groups = await this.userService.getPosts({ id: userId, ...queryParams });
+      return ctx.json(groups, Status.OK);
+    };
+    return await handleAppError(getGroupsImpl)(ctx);
   }
 }

--- a/backend/src/entities/users/controller.ts
+++ b/backend/src/entities/users/controller.ts
@@ -115,7 +115,7 @@ export class UserControllerImpl implements UserController {
       const { limit, page } = ctx.req.query();
       const queryParams = paginationSchema.parse({ limit, page });
       const userId = ctx.get("userId");
-      const groups = await this.userService.getPosts({ id: userId, ...queryParams });
+      const groups = await this.userService.getGroups({ id: userId, ...queryParams });
       return ctx.json(groups, Status.OK);
     };
     return await handleAppError(getGroupsImpl)(ctx);

--- a/backend/src/entities/users/controller.ts
+++ b/backend/src/entities/users/controller.ts
@@ -3,7 +3,6 @@ import { UserService } from "./service";
 import {
   createUserValidate,
   expoTokenValidate,
-  paginationSchema,
   querySchema,
   updateUserValidate,
 } from "./validator";
@@ -18,6 +17,7 @@ import {
   SEARCHED_USERS,
   USER_RESPONSE,
 } from "../../types/api/routes/users";
+import { paginationSchema } from "../../utilities/pagination";
 
 export interface UserController {
   createUser(ctx: Context): Promise<USER_RESPONSE>;

--- a/backend/src/entities/users/controller.ts
+++ b/backend/src/entities/users/controller.ts
@@ -9,7 +9,13 @@ import {
 import { parseUUID } from "../../utilities/uuid";
 import { handleAppError } from "../../utilities/errors/app-error";
 import { Status } from "../../constants/http";
-import { DEL_USER, DEVICE_RESPONSE, USER_RESPONSE } from "../../types/api/routes/users";
+import {
+  DEL_USER,
+  DEVICE_RESPONSE,
+  USER_GROUPS,
+  USER_POSTS,
+  USER_RESPONSE,
+} from "../../types/api/routes/users";
 
 export interface UserController {
   createUser(ctx: Context): Promise<USER_RESPONSE>;
@@ -18,8 +24,8 @@ export interface UserController {
   deleteUser(ctx: Context): Promise<DEL_USER>;
   registerDevice(ctx: Context): Promise<DEVICE_RESPONSE>;
   removeDevice(ctx: Context): Promise<DEVICE_RESPONSE>;
-  getPosts(ctx: Context): Promise<Response>;
-  getGroups(ctx: Context): Promise<Response>;
+  getPosts(ctx: Context): Promise<USER_POSTS>;
+  getGroups(ctx: Context): Promise<USER_GROUPS>;
 }
 
 export class UserControllerImpl implements UserController {
@@ -99,7 +105,7 @@ export class UserControllerImpl implements UserController {
     return await handleAppError(removeDeviceImpl)(ctx);
   }
 
-  async getPosts(ctx: Context): Promise<Response> {
+  async getPosts(ctx: Context): Promise<USER_POSTS> {
     const getPostsImpl = async () => {
       const { limit, page } = ctx.req.query();
       const queryParams = paginationSchema.parse({ limit, page });
@@ -110,7 +116,7 @@ export class UserControllerImpl implements UserController {
     return await handleAppError(getPostsImpl)(ctx);
   }
 
-  async getGroups(ctx: Context): Promise<Response> {
+  async getGroups(ctx: Context): Promise<USER_GROUPS> {
     const getGroupsImpl = async () => {
       const { limit, page } = ctx.req.query();
       const queryParams = paginationSchema.parse({ limit, page });

--- a/backend/src/entities/users/route.ts
+++ b/backend/src/entities/users/route.ts
@@ -17,6 +17,8 @@ export const userRoutes = (db: PostgresJsDatabase): Hono => {
   user.delete("/me", (ctx) => userController.deleteUser(ctx));
   user.post("/devices", (ctx) => userController.registerDevice(ctx));
   user.delete("/devices", (ctx) => userController.removeDevice(ctx));
+  user.get("/posts", (ctx) => userController.getPosts(ctx));
+  user.get("/groups", (ctx) => userController.getGroups(ctx));
 
   return user;
 };

--- a/backend/src/entities/users/route.ts
+++ b/backend/src/entities/users/route.ts
@@ -11,14 +11,14 @@ export const userRoutes = (db: PostgresJsDatabase): Hono => {
   const userService: UserService = new UserServiceImpl(userTransaction);
   const userController: UserController = new UserControllerImpl(userService);
 
+  user.get("/posts", (ctx) => userController.getPosts(ctx));
+  user.get("/groups", (ctx) => userController.getGroups(ctx));
   user.post("/", (ctx) => userController.createUser(ctx));
   user.get("/:id", (ctx) => userController.getUser(ctx));
   user.patch("/me", (ctx) => userController.updateUser(ctx));
   user.delete("/me", (ctx) => userController.deleteUser(ctx));
   user.post("/devices", (ctx) => userController.registerDevice(ctx));
   user.delete("/devices", (ctx) => userController.removeDevice(ctx));
-  user.get("/posts", (ctx) => userController.getPosts(ctx));
-  user.get("/groups", (ctx) => userController.getGroups(ctx));
 
   return user;
 };

--- a/backend/src/entities/users/service.ts
+++ b/backend/src/entities/users/service.ts
@@ -1,7 +1,9 @@
 import { InternalServerError, NotFoundError } from "../../utilities/errors/app-error";
 import { handleServiceError } from "../../utilities/errors/service-error";
-import { CreateUserPayload, UpdateUserPayload, User } from "./validator";
+import { CreateUserPayload, Pagination, UpdateUserPayload, User } from "./validator";
 import { UserTransaction } from "./transaction";
+import { PostWithMedia } from "../posts/validator";
+import { Group } from "../groups/validator";
 
 export interface UserService {
   createUser(payload: CreateUserPayload): Promise<User>;
@@ -10,6 +12,8 @@ export interface UserService {
   deleteUser(id: string): Promise<void>;
   registerDevice(id: string, expoToken: string): Promise<string[]>;
   removeDevice(id: string, expoToken: string): Promise<string[]>;
+  getPosts(payload: Pagination): Promise<PostWithMedia[]>;
+  getGroups(payload: Pagination): Promise<Group[]>;
 }
 
 export class UserServiceImpl implements UserService {
@@ -75,5 +79,19 @@ export class UserServiceImpl implements UserService {
       return devices;
     };
     return handleServiceError(removeDeviceImpl)();
+  }
+
+  async getPosts(payload: Pagination): Promise<PostWithMedia[]> {
+    const getPostsImpl = async () => {
+      return await this.userTransaction.getPosts(payload);
+    };
+    return handleServiceError(getPostsImpl)();
+  }
+
+  async getGroups(payload: Pagination): Promise<Group[]> {
+    const getGroupsImpl = async () => {
+      return await this.userTransaction.getGroups(payload);
+    };
+    return handleServiceError(getGroupsImpl)();
   }
 }

--- a/backend/src/entities/users/transaction.ts
+++ b/backend/src/entities/users/transaction.ts
@@ -100,8 +100,15 @@ export class UserTransactionImpl implements UserTransaction {
         )`,
       })
       .from(postsTable)
-      .innerJoin(mediaTable, eq(mediaTable.id, postsTable.id))
+      .innerJoin(mediaTable, eq(mediaTable.postId, postsTable.id))
       .where(eq(postsTable.userId, id))
+      .groupBy(
+        postsTable.id,
+        postsTable.userId,
+        postsTable.groupId,
+        postsTable.createdAt,
+        postsTable.caption,
+      )
       .orderBy(postsTable.createdAt)
       .limit(limit)
       .offset((page - 1) * limit);

--- a/backend/src/entities/users/transaction.ts
+++ b/backend/src/entities/users/transaction.ts
@@ -138,8 +138,8 @@ export class UserTransactionImpl implements UserTransaction {
       .orderBy(groupsTable.name)
       .limit(limit)
       .offset((page - 1) * limit);
-    }
-    
+  }
+
   async getUsersByUsername({
     userId,
     groupId,

--- a/backend/src/entities/users/transaction.ts
+++ b/backend/src/entities/users/transaction.ts
@@ -123,7 +123,10 @@ export class UserTransactionImpl implements UserTransaction {
         managerId: groupsTable.managerId,
       })
       .from(groupsTable)
-      .innerJoin(membersTable, eq(membersTable.userId, id))
+      .innerJoin(
+        membersTable,
+        and(eq(membersTable.groupId, groupsTable.id), eq(membersTable.userId, id)),
+      )
       .orderBy(groupsTable.name)
       .limit(limit)
       .offset((page - 1) * limit);

--- a/backend/src/entities/users/validator.ts
+++ b/backend/src/entities/users/validator.ts
@@ -42,8 +42,8 @@ export const paginationSchema = z.object({
       const parsed = Number(val);
       return parsed;
     })
-    .refine((val) => !isNaN(val) && val >= 0, {
-      message: "Page must be a non-negative number",
+    .refine((val) => !isNaN(val) && val > 0, {
+      message: "Page must be a positive number",
     })
     .optional()
     .default("1"),

--- a/backend/src/entities/users/validator.ts
+++ b/backend/src/entities/users/validator.ts
@@ -23,3 +23,34 @@ export const expoTokenValidate = z.object({
     message: "Invalid Expo Push Token",
   }),
 });
+
+export const paginationSchema = z.object({
+  limit: z
+    .string()
+    .transform((val) => {
+      const parsed = Number(val);
+      return parsed;
+    })
+    .refine((val) => !isNaN(val) && val > 0, {
+      message: "Limit must be a positive number",
+    })
+    .optional()
+    .default("10"),
+  page: z
+    .string()
+    .transform((val) => {
+      const parsed = Number(val);
+      return parsed;
+    })
+    .refine((val) => !isNaN(val) && val >= 0, {
+      message: "Page must be a non-negative number",
+    })
+    .optional()
+    .default("1"),
+});
+
+export type PaginationParams = z.infer<typeof paginationSchema>;
+
+export type Pagination = PaginationParams & {
+  id: string;
+};

--- a/backend/src/entities/users/validator.ts
+++ b/backend/src/entities/users/validator.ts
@@ -3,6 +3,7 @@ import { createInsertSchema, createUpdateSchema } from "drizzle-zod";
 import z from "zod";
 import { Expo } from "expo-server-sdk";
 import { MIN_LIMIT } from "../../constants/database";
+import { PaginationParams, paginationSchema } from "../../utilities/pagination";
 
 export type CreateUserPayload = typeof usersTable.$inferInsert;
 export type UpdateUserPayload = Partial<typeof usersTable.$inferInsert>;
@@ -40,44 +41,13 @@ export interface SearchedInfo {
   userId: string;
 }
 
-const limitValidate = z
-  .string()
-  .transform((val) => {
-    const parsed = Number(val);
-    return parsed;
-  })
-  .refine((val) => !isNaN(val) && val > 0, {
-    message: "Limit must be a positive number",
-  })
-  .optional()
-  .default("10");
-
-const pageValidate = z
-  .string()
-  .transform((val) => {
-    const parsed = Number(val);
-    return parsed;
-  })
-  .refine((val) => !isNaN(val) && val > 0, {
-    message: "Page must be a positive number",
-  })
-  .optional()
-  .default("1");
-
-export const querySchema = z.object({
-  username: z.string(),
-  groupId: z.string().uuid({ message: "Invalid ID format" }),
-  limit: limitValidate,
-  page: pageValidate,
-});
-
-export const paginationSchema = z.object({
-  limit: limitValidate,
-  page: pageValidate,
-});
-
-export type PaginationParams = z.infer<typeof paginationSchema>;
-
 export type Pagination = PaginationParams & {
   id: string;
 };
+
+export const querySchema = z
+  .object({
+    username: z.string(),
+    groupId: z.string().uuid({ message: "Invalid ID format" }),
+  })
+  .merge(paginationSchema);

--- a/backend/src/tests/helpers/seed-db.ts
+++ b/backend/src/tests/helpers/seed-db.ts
@@ -8,66 +8,42 @@ import {
 } from "../../entities/schema";
 import { CreateUserPayload } from "../../entities/users/validator";
 import {
+  ANOTHER_GROUP,
+  ANOTHER_GROUP_ID,
+  DEARLY_GROUP,
   DEARLY_GROUP_ID,
   MEDIA_MOCK,
   POST_MOCK,
+  USER_ALICE,
   USER_ALICE_ID,
+  USER_ANA,
   USER_ANA_ID,
+  USER_BILL,
+  USER_BOB,
   USER_BOB_ID,
 } from "./test-constants";
 import { CreateGroupPayload } from "../../entities/groups/validator";
 
 export const seedDatabase = async (db: PostgresJsDatabase) => {
-  await seedUser(db);
-  await seedGroup(db);
-  await seedMember(db);
-  await seedPostAndMedia(db);
+  try {
+    await seedUser(db);
+    await seedGroup(db);
+    await seedMember(db);
+    await seedPostAndMedia(db);
+  } catch (error) {
+    console.error("Failed to seed database", error);
+  }
 };
 
 const seedUser = async (db: PostgresJsDatabase) => {
-  const seedData: CreateUserPayload[] = [
-    {
-      name: "Alice",
-      username: "alice123",
-      mode: "BASIC",
-      id: USER_ALICE_ID,
-    },
-    {
-      name: "Bob",
-      username: "bobthebuilder",
-      mode: "ADVANCED",
-      id: USER_BOB_ID,
-    },
-    {
-      name: "Ana",
-      username: "ana",
-      mode: "BASIC",
-      id: USER_ANA_ID,
-    },
-  ];
-
-  try {
-    await db.insert(usersTable).values(seedData);
-  } catch (error) {
-    console.error("Error seeding database:", error);
-  }
+  const seedData: CreateUserPayload[] = [USER_ALICE, USER_ANA, USER_BOB, USER_BILL];
+  await db.insert(usersTable).values(seedData);
 };
 
 const seedGroup = async (db: PostgresJsDatabase) => {
-  const seedData: CreateGroupPayload[] = [
-    {
-      name: "dearly",
-      description: "dearly",
-      managerId: USER_ALICE_ID,
-      id: DEARLY_GROUP_ID,
-    },
-  ];
+  const seedData: CreateGroupPayload[] = [DEARLY_GROUP, ANOTHER_GROUP];
 
-  try {
-    await db.insert(groupsTable).values(seedData);
-  } catch (error) {
-    console.error("Error seeding database:", error);
-  }
+  await db.insert(groupsTable).values(seedData);
 };
 
 const seedMember = async (db: PostgresJsDatabase) => {
@@ -82,20 +58,22 @@ const seedMember = async (db: PostgresJsDatabase) => {
       groupId: DEARLY_GROUP_ID,
       role: "MEMBER",
     },
+    {
+      userId: USER_ANA_ID,
+      groupId: ANOTHER_GROUP_ID,
+      role: "MANAGER",
+    },
+    {
+      userId: USER_ALICE_ID,
+      groupId: ANOTHER_GROUP_ID,
+      role: "MEMBER",
+    },
   ];
 
-  try {
-    await db.insert(membersTable).values(seedData);
-  } catch (error) {
-    console.error("Error seeding database:", error);
-  }
+  await db.insert(membersTable).values(seedData);
 };
 
 const seedPostAndMedia = async (db: PostgresJsDatabase) => {
-  try {
-    await db.insert(postsTable).values(POST_MOCK);
-    await db.insert(mediaTable).values(MEDIA_MOCK);
-  } catch (error) {
-    console.error("Error seeding database:", error);
-  }
+  await db.insert(postsTable).values(POST_MOCK);
+  await db.insert(mediaTable).values(MEDIA_MOCK);
 };

--- a/backend/src/tests/helpers/test-constants.ts
+++ b/backend/src/tests/helpers/test-constants.ts
@@ -1,14 +1,18 @@
+import { CreateGroupPayload } from "../../entities/groups/validator";
 import { mediaTable, postsTable } from "../../entities/schema";
+import { CreateUserPayload } from "../../entities/users/validator";
 
 export const INVALID_ID_ARRAY = ["1", "%2", "123abc", "!!$$", "123 456", "@ID", null, undefined];
 export const USER_ALICE_ID = "00000000-0000-0000-0000-000000000000";
 export const USER_BOB_ID = "ae6be85f-157c-40db-afd2-2f388d8ff7b5";
 export const USER_ANA_ID = "6d56421d-4c0d-44d9-b2b1-8d897207fc5b";
+export const USER_BILL_ID = "e8f8a2d1-57c7-4b71-9c8b-9b5f09a9db49";
 export const DEARLY_GROUP_ID = "ab674eaf-e6f0-47c1-8a38-81079577880b";
 export const POST_ID = "d1c51f6d-3a57-474a-872e-bde646fe338b";
 export const MEDIA_ONE_ID = "c41f01cf-2c1b-44ad-b80f-05bddd607ee1";
 export const MEDIA_TWO_ID = "43bd915c-122c-448f-8d2b-bdc983934e86";
 export const MEDIA_THREE_ID = "43bd915c-122c-448f-8d2b-bdc983934e86";
+export const ANOTHER_GROUP_ID = "678d8ff3-c24c-8002-ad06-052ae4f44075";
 
 export const GROUP_EMPTY_FIELDS_ERRORS = [
   {
@@ -57,3 +61,45 @@ export const POST_MOCK: (typeof postsTable.$inferInsert)[] = [
     caption: "my first post",
   },
 ];
+
+export const USER_ALICE: CreateUserPayload = {
+  name: "Alice",
+  username: "alice123",
+  mode: "BASIC",
+  id: USER_ALICE_ID,
+};
+
+export const USER_BOB: CreateUserPayload = {
+  name: "Bob",
+  username: "bobthebuilder",
+  mode: "ADVANCED",
+  id: USER_BOB_ID,
+};
+
+export const USER_ANA: CreateUserPayload = {
+  name: "Ana",
+  username: "ana",
+  mode: "BASIC",
+  id: USER_ANA_ID,
+};
+
+export const USER_BILL: CreateUserPayload = {
+  name: "Bill",
+  username: "bill",
+  mode: "BASIC",
+  id: USER_BILL_ID,
+};
+
+export const DEARLY_GROUP: CreateGroupPayload = {
+  name: "dearly",
+  description: "dearly",
+  managerId: USER_ALICE_ID,
+  id: DEARLY_GROUP_ID,
+};
+
+export const ANOTHER_GROUP: CreateGroupPayload = {
+  name: "family",
+  description: "family",
+  managerId: USER_ANA_ID,
+  id: ANOTHER_GROUP_ID,
+};

--- a/backend/src/tests/helpers/test-constants.ts
+++ b/backend/src/tests/helpers/test-constants.ts
@@ -61,6 +61,13 @@ export const POST_MOCK: (typeof postsTable.$inferInsert)[] = [
     createdAt: new Date(),
     caption: "my first post",
   },
+  {
+    userId: USER_ANA_ID,
+    groupId: DEARLY_GROUP_ID,
+    id: NEW_POST_ID,
+    createdAt: new Date(),
+    caption: "a chill weekend"
+  }
 ];
 
 export const USER_ALICE: CreateUserPayload = {

--- a/backend/src/tests/helpers/test-constants.ts
+++ b/backend/src/tests/helpers/test-constants.ts
@@ -11,8 +11,9 @@ export const DEARLY_GROUP_ID = "ab674eaf-e6f0-47c1-8a38-81079577880b";
 export const POST_ID = "d1c51f6d-3a57-474a-872e-bde646fe338b";
 export const MEDIA_ONE_ID = "c41f01cf-2c1b-44ad-b80f-05bddd607ee1";
 export const MEDIA_TWO_ID = "43bd915c-122c-448f-8d2b-bdc983934e86";
-export const MEDIA_THREE_ID = "43bd915c-122c-448f-8d2b-bdc983934e86";
+export const MEDIA_THREE_ID = "a9c2d3f7-5b84-42e1-91f0-3d6a8b4c7e12";
 export const ANOTHER_GROUP_ID = "678d8ff3-c24c-8002-ad06-052ae4f44075";
+export const NEW_POST_ID = "e3f4b2c1-8d67-4f9b-90a4-6b1f3d2e5c78";
 
 export const GROUP_EMPTY_FIELDS_ERRORS = [
   {

--- a/backend/src/tests/helpers/test-constants.ts
+++ b/backend/src/tests/helpers/test-constants.ts
@@ -66,8 +66,8 @@ export const POST_MOCK: (typeof postsTable.$inferInsert)[] = [
     groupId: DEARLY_GROUP_ID,
     id: NEW_POST_ID,
     createdAt: new Date(),
-    caption: "a chill weekend"
-  }
+    caption: "a chill weekend",
+  },
 ];
 
 export const USER_ALICE: CreateUserPayload = {

--- a/backend/src/tests/users/groups.test.ts
+++ b/backend/src/tests/users/groups.test.ts
@@ -1,0 +1,148 @@
+import { Hono } from "hono";
+import { startTestApp } from "../helpers/test-app";
+import { TestBuilder } from "../helpers/test-builder";
+import { generateJWTFromID } from "../helpers/test-token";
+import { HTTPRequest, Status } from "../../constants/http";
+import {
+  ANOTHER_GROUP,
+  DEARLY_GROUP,
+  USER_ALICE_ID,
+  USER_ANA_ID,
+  USER_BILL_ID,
+  USER_BOB_ID,
+} from "../helpers/test-constants";
+
+describe("GET /users/search", () => {
+  let app: Hono;
+  const testBuilder = new TestBuilder();
+
+  beforeAll(async () => {
+    app = await startTestApp();
+  });
+
+  it("should return 200 if user not found", async () => {
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.GET,
+        route: `/api/v1/users/groups`,
+        queryParams: {
+          limit: "1",
+          page: "1",
+        },
+        autoAuthorized: false,
+        headers: {
+          Authorization: `Bearer ${generateJWTFromID()}`,
+        },
+      })
+    )
+      .debug()
+      .assertStatusCode(Status.OK)
+      .assertBody([]);
+  });
+
+  it.each([
+    [USER_ANA_ID, [ANOTHER_GROUP]],
+    [USER_BOB_ID, [DEARLY_GROUP]],
+    [USER_BILL_ID, []],
+    [USER_ALICE_ID, [DEARLY_GROUP, ANOTHER_GROUP]],
+  ])("should return 200 if for user with ID %s", async (id, expectedGroups) => {
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.GET,
+        route: `/api/v1/users/groups`,
+        autoAuthorized: false,
+        headers: {
+          Authorization: `Bearer ${generateJWTFromID(id)}`,
+        },
+      })
+    )
+      .assertStatusCode(Status.OK)
+      .assertBody(expectedGroups);
+  });
+
+  it.each([
+    ["1", "1", [DEARLY_GROUP]],
+    ["1", "2", [ANOTHER_GROUP]],
+    ["1", "3", []],
+    ["2", "1", [DEARLY_GROUP, ANOTHER_GROUP]],
+    ["2", "2", []],
+  ])("should return 200 with limit %s and page %s", async (limit, page, expectedBody) => {
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.GET,
+        route: `/api/v1/users/groups`,
+        queryParams: {
+          limit,
+          page,
+        },
+        autoAuthorized: false,
+        headers: {
+          Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
+        },
+      })
+    )
+      .assertStatusCode(Status.OK)
+      .assertBody(expectedBody);
+  });
+
+  it("should return 400 if limit and page not number", async () => {
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.GET,
+        route: `/api/v1/users/groups`,
+        queryParams: {
+          limit: "limit",
+          page: "page",
+        },
+        autoAuthorized: false,
+        headers: {
+          Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
+        },
+      })
+    )
+      .assertStatusCode(Status.BadRequest)
+      .assertError([
+        {
+          message: "Limit must be a positive number",
+          path: "limit",
+        },
+        {
+          message: "Page must be a positive number",
+          path: "page",
+        },
+      ]);
+  });
+
+  it("should return 400 if limit and page is not positive", async () => {
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.GET,
+        route: `/api/v1/users/groups`,
+        queryParams: {
+          limit: "0",
+          page: "-1",
+        },
+        autoAuthorized: false,
+        headers: {
+          Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
+        },
+      })
+    )
+      .assertStatusCode(Status.BadRequest)
+      .assertError([
+        {
+          message: "Limit must be a positive number",
+          path: "limit",
+        },
+        {
+          message: "Page must be a positive number",
+          path: "page",
+        },
+      ]);
+  });
+});

--- a/backend/src/tests/users/posts.test.ts
+++ b/backend/src/tests/users/posts.test.ts
@@ -31,7 +31,6 @@ describe("GET /users/search", () => {
         },
       })
     )
-      .debug()
       .assertStatusCode(Status.OK)
       .assertBody([]);
   });

--- a/backend/src/tests/users/posts.test.ts
+++ b/backend/src/tests/users/posts.test.ts
@@ -4,10 +4,9 @@ import { TestBuilder } from "../helpers/test-builder";
 import { generateJWTFromID } from "../helpers/test-token";
 import { HTTPRequest, Status } from "../../constants/http";
 import {
-  ANOTHER_GROUP,
-  DEARLY_GROUP,
+  MEDIA_MOCK,
+  POST_MOCK,
   USER_ALICE_ID,
-  USER_ANA_ID,
   USER_BILL_ID,
   USER_BOB_ID,
 } from "../helpers/test-constants";
@@ -25,32 +24,37 @@ describe("GET /users/search", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/users/groups`,
-        queryParams: {
-          limit: "1",
-          page: "1",
-        },
+        route: `/api/v1/users/posts`,
         autoAuthorized: false,
         headers: {
           Authorization: `Bearer ${generateJWTFromID()}`,
         },
       })
     )
+      .debug()
       .assertStatusCode(Status.OK)
       .assertBody([]);
   });
 
   it.each([
-    [USER_ANA_ID, [ANOTHER_GROUP]],
-    [USER_BOB_ID, [DEARLY_GROUP]],
+    [USER_BOB_ID, []],
     [USER_BILL_ID, []],
-    [USER_ALICE_ID, [DEARLY_GROUP, ANOTHER_GROUP]],
-  ])("should return 200 if for user with ID %s", async (id, expectedGroups) => {
+    [
+      USER_ALICE_ID,
+      [
+        {
+          ...POST_MOCK[0],
+          media: MEDIA_MOCK,
+          createdAt: POST_MOCK[0]!.createdAt?.toISOString(),
+        },
+      ],
+    ],
+  ])("should return 200 if for user with ID %s", async (id, expectedPosts) => {
     (
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/users/groups`,
+        route: `/api/v1/users/posts`,
         autoAuthorized: false,
         headers: {
           Authorization: `Bearer ${generateJWTFromID(id)}`,
@@ -58,21 +62,41 @@ describe("GET /users/search", () => {
       })
     )
       .assertStatusCode(Status.OK)
-      .assertBody(expectedGroups);
+      .assertBody(expectedPosts);
   });
 
   it.each([
-    ["1", "1", [DEARLY_GROUP]],
-    ["1", "2", [ANOTHER_GROUP]],
+    [
+      "1",
+      "1",
+      [
+        {
+          ...POST_MOCK[0],
+          media: MEDIA_MOCK,
+          createdAt: POST_MOCK[0]!.createdAt?.toISOString(),
+        },
+      ],
+    ],
+    ["1", "2", []],
     ["1", "3", []],
-    ["2", "1", [DEARLY_GROUP, ANOTHER_GROUP]],
+    [
+      "2",
+      "1",
+      [
+        {
+          ...POST_MOCK[0],
+          media: MEDIA_MOCK,
+          createdAt: POST_MOCK[0]!.createdAt?.toISOString(),
+        },
+      ],
+    ],
     ["2", "2", []],
   ])("should return 200 with limit %s and page %s", async (limit, page, expectedBody) => {
     (
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/users/groups`,
+        route: `/api/v1/users/posts`,
         queryParams: {
           limit,
           page,
@@ -92,7 +116,7 @@ describe("GET /users/search", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/users/groups`,
+        route: `/api/v1/users/posts`,
         queryParams: {
           limit: "limit",
           page: "page",
@@ -121,7 +145,7 @@ describe("GET /users/search", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/users/groups`,
+        route: `/api/v1/users/posts`,
         queryParams: {
           limit: "0",
           page: "-1",

--- a/backend/src/types/api/routes/users.ts
+++ b/backend/src/types/api/routes/users.ts
@@ -12,3 +12,10 @@ export type DEVICE_RESPONSE = TypedResponse<
   | paths["/api/v1/users/devices"]["delete"]["responses"]["200"]["content"]["application/json"]
   | API_ERROR
 >;
+export type USER_POSTS = TypedResponse<
+  paths["/api/v1/users/posts"]["get"]["responses"]["200"]["content"]["application/json"] | API_ERROR
+>;
+export type USER_GROUPS = TypedResponse<
+  | paths["/api/v1/users/groups"]["get"]["responses"]["200"]["content"]["application/json"]
+  | API_ERROR
+>;

--- a/backend/src/utilities/pagination.ts
+++ b/backend/src/utilities/pagination.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const paginationSchema = z.object({
+  limit: z
+    .string()
+    .transform((val) => {
+      const parsed = Number(val);
+      return parsed;
+    })
+    .refine((val) => !isNaN(val) && val > 0, {
+      message: "Limit must be a positive number",
+    })
+    .optional()
+    .default("10"),
+  page: z
+    .string()
+    .transform((val) => {
+      const parsed = Number(val);
+      return parsed;
+    })
+    .refine((val) => !isNaN(val) && val > 0, {
+      message: "Page must be a positive number",
+    })
+    .optional()
+    .default("1"),
+});
+
+export type PaginationParams = z.infer<typeof paginationSchema>;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -497,7 +497,25 @@ paths:
                 schema:
                   type: array
                   items:
-                    $ref: "#/components/schemas/Group"
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: The name of the group.
+                      description:
+                        type: string
+                        description: A description of the group.
+                        nullable: true
+                      id:
+                        type: string
+                        format: uuid
+                        example: 5e91507e-5630-4efd-9fd4-799178870b10
+                        description: A unique identifier for the group.
+                      managerId:
+                        type: string
+                        format: uuid
+                        example: 5e91507e-5630-4efd-9fd4-799178870b10
+                        description: A unique identifier of the group manager.
           400:
             description: Malformed query params
             content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -79,6 +79,7 @@ components:
         description:
           type: string
           description: A description of the group.
+          nullable: true
       required:
         - name
     Post:
@@ -451,9 +452,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/Error"
-                  - $ref: "#/components/schemas/ValidationError"
+                $ref: "#/components/schemas/ValidationError"
         401:
           description: Unauthorized due to invalid JWT
           content:
@@ -466,6 +465,111 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+  /api/v1/users/groups:
+      get:
+        tags: 
+          - User Endpoints
+        summary: Get all groups for user
+        description: Get all groups user is member of.
+        security: 
+          - BearerAuth: []
+        parameters:
+          - name: limit
+            in: query
+            description: The maximum number of groups to return.
+            required: false
+            schema:
+              type: integer
+              default: 10
+          - name: page
+            in: query
+            description: The page number for pagination.
+            required: false
+            schema:
+              type: integer
+              default: 1
+        responses:
+          200:
+            description: Successfully retrieve groups user is part of
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/Group"
+          400:
+            description: Malformed query params
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/ValidationError"
+          401:
+            description: Unauthorized due to invalid JWT
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Error"
+          500:
+            description: Internal server error
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Error"
+
+  /api/v1/users/posts:
+      get:
+        tags: 
+          - User Endpoints
+        summary: Get all posts for user
+        description: Get all posts that a user posted.
+        security: 
+          - BearerAuth: []
+        parameters:
+          - name: limit
+            in: query
+            description: The maximum number of posts to return.
+            required: false
+            schema:
+              type: integer
+              default: 10
+          - name: page
+            in: query
+            description: The page number for pagination.
+            required: false
+            schema:
+              type: integer
+              default: 1
+        responses:
+          200:
+            description: Successfully retrieve posts user posted
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/Post"
+          400:
+            description: Malformed query params
+            content:
+              application/json:
+                schema:
+                  oneOf:
+                    - $ref: "#/components/schemas/Error"
+                    - $ref: "#/components/schemas/ValidationError"
+          401:
+            description: Unauthorized due to invalid JWT
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Error"
+          500:
+            description: Internal server error
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Error"
+
   /api/v1/users/devices:
     post:
       tags:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, the issue being fixed (if applicable), motivation and context, and anything that we should look out for. -->
Paginated GET endpoints that allow for retrieving all user's posts or groups. 

### Test cases ensure that API:
- Rejects bad limit and page (offset) value such as non-positive numbers and non-number.
- Return correct amount of items with changing limit and offset.

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added necessary tests (unit, integration, etc.) to cover the new functionality or fix.
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation to reflect changes (e.g., README, code comments).
- [x] I have removed any commented-out code, debug statements, or unnecessary console logs.
