### PR TITLE
fix: simplify posts route by removing groupId

### DIFF
--- a/backend/src/entities/posts/controller.ts
+++ b/backend/src/entities/posts/controller.ts
@@ -28,7 +28,7 @@ export class PostControllerImpl implements PostController {
   async createPost(ctx: Context): Promise<POST_API> {
     const createPostImpl = async () => {
       // pull out essential IDs
-      const groupId = parseUUID(ctx.req.param("groupId"));
+      const groupId = parseUUID(ctx.req.param("id"));
       const userId = parseUUID(ctx.get("userId"));
 
       // validate input
@@ -49,11 +49,10 @@ export class PostControllerImpl implements PostController {
   async getPost(ctx: Context): Promise<POST_API> {
     const getPostImpl = async () => {
       // pull out essential IDs
-      const id = parseUUID(ctx.req.param("postId"));
+      const id = parseUUID(ctx.req.param("id"));
       const userId = parseUUID(ctx.get("userId"));
-      const groupId = parseUUID(ctx.req.param("groupId"));
 
-      const post = await this.postService.getPost({ userId, id, groupId });
+      const post = await this.postService.getPost({ userId, id });
       return ctx.json(post, Status.OK);
     };
     return await handleAppError(getPostImpl)(ctx);
@@ -63,8 +62,7 @@ export class PostControllerImpl implements PostController {
     const updatePostImpl = async () => {
       // pull out essential IDs
       const userId = parseUUID(ctx.get("userId"));
-      const postId = parseUUID(ctx.req.param("postId"));
-      const groupId = parseUUID(ctx.req.param("groupId"));
+      const postId = parseUUID(ctx.req.param("id"));
 
       // validate update payload
       const postInfoPayload = updatePostValidate.parse(await ctx.req.json());
@@ -74,7 +72,6 @@ export class PostControllerImpl implements PostController {
         userId,
         id: postId,
         ...postInfoPayload,
-        groupId,
       };
       const post = await this.postService.updatePost(updatePostPayload);
       return ctx.json(post, Status.OK);
@@ -85,11 +82,10 @@ export class PostControllerImpl implements PostController {
   async deletePost(ctx: Context): Promise<DEL_POST> {
     const deletePostImpl = async () => {
       // pull out essential IDs
-      const id = parseUUID(ctx.req.param("postId"));
+      const id = parseUUID(ctx.req.param("id"));
       const userId = parseUUID(ctx.get("userId"));
-      const groupId = parseUUID(ctx.req.param("groupId"));
 
-      await this.postService.deletePost({ userId, id, groupId });
+      await this.postService.deletePost({ userId, id });
       return ctx.json({ message: "Successfully delete post" }, Status.OK);
     };
     return await handleAppError(deletePostImpl)(ctx);

--- a/backend/src/entities/posts/route.ts
+++ b/backend/src/entities/posts/route.ts
@@ -11,10 +11,10 @@ export const postRoutes = (db: PostgresJsDatabase): Hono => {
   const postService: PostService = new PostServiceImpl(postTransaction);
   const postController: PostController = new PostControllerImpl(postService);
 
-  post.post("/", (ctx) => postController.createPost(ctx));
-  post.get("/:postId", (ctx) => postController.getPost(ctx));
-  post.patch("/:postId", (ctx) => postController.updatePost(ctx));
-  post.delete("/:postId", (ctx) => postController.deletePost(ctx));
+  post.post("/groups/:id/posts", (ctx) => postController.createPost(ctx));
+  post.get("/posts/:id", (ctx) => postController.getPost(ctx));
+  post.patch("/posts/:id", (ctx) => postController.updatePost(ctx));
+  post.delete("/posts/:id", (ctx) => postController.deletePost(ctx));
 
   return post;
 };

--- a/backend/src/entities/posts/service.ts
+++ b/backend/src/entities/posts/service.ts
@@ -50,9 +50,9 @@ export class PostServiceImpl implements PostService {
     return await handleServiceError(updatePostImpl)();
   }
 
-  async deletePost(payload: IDPayload): Promise<void> {
+  async deletePost({ id, userId }: IDPayload): Promise<void> {
     const deletePostImpl = async () => {
-      await this.postTransaction.deletePost(payload.id, payload.userId);
+      await this.postTransaction.deletePost(id, userId);
     };
     return await handleServiceError(deletePostImpl)();
   }

--- a/backend/src/entities/posts/transaction.ts
+++ b/backend/src/entities/posts/transaction.ts
@@ -64,7 +64,7 @@ export class PostTransactionImpl implements PostTransaction {
     return postWithMedia;
   }
 
-  async getPost(payload: IDPayload): Promise<PostWithMedia | null> {
+  async getPost({ id, userId }: IDPayload): Promise<PostWithMedia | null> {
     const [result] = await this.db
       .select({
         id: postsTable.id,
@@ -86,7 +86,7 @@ export class PostTransactionImpl implements PostTransaction {
       .innerJoin(groupsTable, eq(postsTable.groupId, groupsTable.id))
       .innerJoin(
         membersTable,
-        and(eq(groupsTable.id, membersTable.groupId), eq(membersTable.userId, payload.userId)),
+        and(eq(groupsTable.id, membersTable.groupId), eq(membersTable.userId, userId)),
       )
       .groupBy(
         postsTable.id,
@@ -95,7 +95,7 @@ export class PostTransactionImpl implements PostTransaction {
         postsTable.createdAt,
         postsTable.caption,
       )
-      .where(eq(postsTable.id, payload.id));
+      .where(eq(postsTable.id, id));
 
     if (!result) return null;
 

--- a/backend/src/entities/posts/transaction.ts
+++ b/backend/src/entities/posts/transaction.ts
@@ -103,29 +103,37 @@ export class PostTransactionImpl implements PostTransaction {
     return result;
   }
 
-  async updatePost(payload: UpdatePostPayload): Promise<PostWithMedia | null> {
-    await this.checkPostOwnership(payload.id, payload.userId);
+  async updatePost({
+    id,
+    userId,
+    caption,
+    media,
+  }: UpdatePostPayload): Promise<PostWithMedia | null> {
+    await this.checkPostOwnership(id, userId);
 
     // update post
     const updatedPostWithMedia = await this.db.transaction(async (tx) => {
       const [updatedPost] = await tx
         .update(postsTable)
-        .set({ caption: payload.caption })
-        .where(and(eq(postsTable.id, payload.id), eq(postsTable.userId, payload.userId)))
+        .set({ caption: caption })
+        .where(and(eq(postsTable.id, id), eq(postsTable.userId, userId)))
         .returning();
 
       if (!updatedPost) return null;
 
       // update associated media
-      let media;
-      if (payload.media) {
-        await tx.delete(mediaTable).where(eq(mediaTable.postId, payload.id));
-        media = await tx
+      let updatedMedia;
+      if (media) {
+        await tx.delete(mediaTable).where(eq(mediaTable.postId, id));
+        updatedMedia = await tx
           .insert(mediaTable)
-          .values(payload.media.map((m) => ({ postId: updatedPost.id, ...m })))
+          .values(media.map((m) => ({ postId: updatedPost.id, ...m })))
           .returning();
       } else {
-        media = await tx.select().from(mediaTable).where(eq(mediaTable.postId, updatedPost.id));
+        updatedMedia = await tx
+          .select()
+          .from(mediaTable)
+          .where(eq(mediaTable.postId, updatedPost.id));
       }
 
       return {
@@ -134,7 +142,7 @@ export class PostTransactionImpl implements PostTransaction {
         groupId: updatedPost.groupId,
         caption: updatedPost.caption,
         createdAt: updatedPost.createdAt,
-        media: media,
+        media: updatedMedia,
       };
     });
 

--- a/backend/src/entities/posts/validator.ts
+++ b/backend/src/entities/posts/validator.ts
@@ -40,7 +40,6 @@ export type UpdatePostPayload = z.infer<typeof updatePostValidate> & IDPayload;
 export type IDPayload = {
   userId: string;
   id: string;
-  groupId: string;
 };
 
 export type Media = typeof mediaTable.$inferSelect;

--- a/backend/src/routes/init.ts
+++ b/backend/src/routes/init.ts
@@ -36,7 +36,7 @@ const apiRoutes = (db: PostgresJsDatabase): Hono => {
 
   api.route("/users", userRoutes(db));
   api.route("/groups", groupRoutes(db));
-  api.route("/groups/:groupId/posts", postRoutes(db));
+  api.route("/", postRoutes(db));
 
   return api;
 };

--- a/backend/src/tests/posts/create.test.ts
+++ b/backend/src/tests/posts/create.test.ts
@@ -12,7 +12,7 @@ import { generateJWTFromID, generateUUID } from "../helpers/test-token";
 import { HTTPRequest, Status } from "../../constants/http";
 import { MAX_MEDIA_COUNT, MIN_LIMIT, TEXT_MAX_LIMIT } from "../../constants/database";
 
-describe("POST /groups/:groupId/posts", () => {
+describe("POST /groups/:id/posts", () => {
   let app: Hono;
   const testBuilder = new TestBuilder();
   const goodRequestBody = {

--- a/backend/src/tests/posts/delete.test.ts
+++ b/backend/src/tests/posts/delete.test.ts
@@ -11,7 +11,7 @@ import { TestBuilder } from "../helpers/test-builder";
 import { generateJWTFromID, generateUUID } from "../helpers/test-token";
 import { HTTPRequest, Status } from "../../constants/http";
 
-describe("DELETE /groups/:groupId/posts/:postId", () => {
+describe("DELETE /posts/:id", () => {
   let app: Hono;
   const testBuilder = new TestBuilder();
   const goodRequestBody = {
@@ -67,7 +67,7 @@ describe("DELETE /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.DELETE,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${id}`,
+        route: `/api/v1/posts/${id}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -85,7 +85,7 @@ describe("DELETE /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.DELETE,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${id}`,
+        route: `/api/v1/posts/${id}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -103,7 +103,7 @@ describe("DELETE /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.DELETE,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${id}`,
+        route: `/api/v1/posts/${id}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -122,7 +122,7 @@ describe("DELETE /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${generateUUID()}`,
+        route: `/api/v1/posts/${generateUUID()}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -136,31 +136,12 @@ describe("DELETE /groups/:groupId/posts/:postId", () => {
       .assertError("Post does not exist.");
   });
 
-  it("should return 400 if invalid group ID", async () => {
-    (
-      await testBuilder.request({
-        app,
-        type: HTTPRequest.GET,
-        route: `/api/v1/groups/bad/posts/${generateUUID()}`,
-        requestBody: {
-          ...goodRequestBody,
-        },
-        autoAuthorized: false,
-        headers: {
-          Authorization: `Bearer ${ALICE_JWT}`,
-        },
-      })
-    )
-      .assertStatusCode(Status.BadRequest)
-      .assertError("Invalid ID format");
-  });
-
   it("should return 400 if invalid post ID", async () => {
     (
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/bad`,
+        route: `/api/v1/posts/bad`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -181,19 +162,7 @@ describe("DELETE /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.DELETE,
-        route: `/api/v1/groups/${generateUUID()}/posts/${id}`,
-      })
-    ).assertStatusCode(Status.BadRequest);
-  });
-
-  it.each(
-    INVALID_ID_ARRAY.map((id) => [id === null ? "null" : id === undefined ? "undefined" : id, id]),
-  )("should return 400 if invalid groupId %s", async (id) => {
-    (
-      await testBuilder.request({
-        app,
-        type: HTTPRequest.DELETE,
-        route: `/api/v1/groups/${id}/posts/${generateUUID()}`,
+        route: `/api/v1/posts/${id}`,
       })
     ).assertStatusCode(Status.BadRequest);
   });

--- a/backend/src/tests/posts/get.test.ts
+++ b/backend/src/tests/posts/get.test.ts
@@ -14,7 +14,7 @@ import { TestBuilder } from "../helpers/test-builder";
 import { generateJWTFromID, generateUUID } from "../helpers/test-token";
 import { HTTPRequest, Status } from "../../constants/http";
 
-describe("GET /groups/:groupId/posts/:postId", () => {
+describe("GET /posts/:id", () => {
   let app: Hono;
   const testBuilder = new TestBuilder();
   const goodRequestBody = {
@@ -54,7 +54,7 @@ describe("GET /groups/:groupId/posts/:postId", () => {
         },
       })
     )
-      .assertStatusCode(201)
+      .assertStatusCode(Status.Created)
       .assertFieldExists("id")
       .assertFieldExists("createdAt")
       .assertFieldExists("media")
@@ -70,7 +70,7 @@ describe("GET /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${id}`,
+        route: `/api/v1/posts/${id}`,
         autoAuthorized: false,
         headers: {
           Authorization: `Bearer ${BOB_JWT}`,
@@ -83,7 +83,7 @@ describe("GET /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${id}`,
+        route: `/api/v1/posts/${id}`,
         autoAuthorized: false,
         headers: {
           Authorization: `Bearer ${ALICE_JWT}`,
@@ -97,7 +97,7 @@ describe("GET /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${POST_ID}`,
+        route: `/api/v1/posts/${POST_ID}`,
         autoAuthorized: false,
         headers: {
           Authorization: `Bearer ${ALICE_JWT}`,
@@ -134,7 +134,7 @@ describe("GET /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${id}`,
+        route: `/api/v1/posts/${id}`,
         autoAuthorized: false,
         headers: {
           Authorization: `Bearer ${ANA_JWT}`,
@@ -147,7 +147,7 @@ describe("GET /groups/:groupId/posts/:postId", () => {
     await testBuilder.request({
       app,
       type: HTTPRequest.GET,
-      route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${generateUUID()}`,
+      route: `/api/v1/posts/${generateUUID()}`,
       autoAuthorized: false,
       headers: {
         Authorization: `Bearer ${BOB_JWT}`,
@@ -155,12 +155,12 @@ describe("GET /groups/:groupId/posts/:postId", () => {
     });
   });
 
-  it("should return 404 if group not found", async () => {
+  it("should return 404 if post not found", async () => {
     (
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/groups/${generateUUID()}/posts/${generateUUID()}`,
+        route: `/api/v1/posts/${generateUUID()}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -181,19 +181,7 @@ describe("GET /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.GET,
-        route: `/api/v1/groups/${generateUUID()}/posts/${id}`,
-      })
-    ).assertStatusCode(Status.BadRequest);
-  });
-
-  it.each(
-    INVALID_ID_ARRAY.map((id) => [id === null ? "null" : id === undefined ? "undefined" : id, id]),
-  )("should return 400 if invalid groupId %s", async (id) => {
-    (
-      await testBuilder.request({
-        app,
-        type: HTTPRequest.GET,
-        route: `/api/v1/groups/${id}/posts/${generateUUID()}`,
+        route: `/api/v1/posts/${id}`,
       })
     ).assertStatusCode(Status.BadRequest);
   });

--- a/backend/src/tests/posts/update.test.ts
+++ b/backend/src/tests/posts/update.test.ts
@@ -1,7 +1,6 @@
 import {
   USER_ANA_ID,
   USER_BOB_ID,
-  DEARLY_GROUP_ID,
   USER_ALICE_ID,
   POST_ID,
   POST_MOCK,
@@ -15,7 +14,7 @@ import { generateJWTFromID, generateUUID } from "../helpers/test-token";
 import { HTTPRequest, Status } from "../../constants/http";
 import { MAX_MEDIA_COUNT, MIN_LIMIT, TEXT_MAX_LIMIT } from "../../constants/database";
 
-describe("PATCH /groups/:groupId/posts/:postId", () => {
+describe("PATCH /posts/:id", () => {
   let app: Hono;
   const testBuilder = new TestBuilder();
   const goodRequestBody = {
@@ -45,7 +44,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${POST_ID}`,
+        route: `/api/v1/posts/${POST_ID}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -66,7 +65,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${POST_ID}`,
+        route: `/api/v1/posts/${POST_ID}`,
         requestBody: {
           caption: "",
         },
@@ -90,7 +89,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${POST_ID}`,
+        route: `/api/v1/posts/${POST_ID}`,
         requestBody: {
           caption: "a".repeat(TEXT_MAX_LIMIT + 1),
         },
@@ -114,7 +113,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${POST_ID}`,
+        route: `/api/v1/posts/${POST_ID}`,
         requestBody: {
           media: [],
         },
@@ -138,7 +137,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${POST_ID}`,
+        route: `/api/v1/posts/${POST_ID}`,
         requestBody: {
           media: [
             {
@@ -178,8 +177,8 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
     (
       await testBuilder.request({
         app,
-        type: HTTPRequest.POST,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts`,
+        type: HTTPRequest.PATCH,
+        route: `/api/v1/posts/${generateUUID()}`,
         requestBody: {
           media: [
             {
@@ -212,7 +211,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${generateUUID()}`,
+        route: `/api/v1/posts/${generateUUID()}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -231,7 +230,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${generateUUID()}/posts/${generateUUID()}`,
+        route: `/api/v1/posts/${generateUUID()}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -250,7 +249,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${POST_ID}`,
+        route: `/api/v1/posts/${POST_ID}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -267,7 +266,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${DEARLY_GROUP_ID}/posts/${POST_ID}`,
+        route: `/api/v1/posts/${POST_ID}`,
         requestBody: {
           ...goodRequestBody,
         },
@@ -286,19 +285,7 @@ describe("PATCH /groups/:groupId/posts/:postId", () => {
       await testBuilder.request({
         app,
         type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${generateUUID()}/posts/${id}`,
-      })
-    ).assertStatusCode(Status.BadRequest);
-  });
-
-  it.each(
-    INVALID_ID_ARRAY.map((id) => [id === null ? "null" : id === undefined ? "undefined" : id, id]),
-  )("should return 400 if invalid groupId %s", async (id) => {
-    (
-      await testBuilder.request({
-        app,
-        type: HTTPRequest.PATCH,
-        route: `/api/v1/groups/${id}/posts/${generateUUID()}`,
+        route: `/api/v1/posts/${id}`,
       })
     ).assertStatusCode(Status.BadRequest);
   });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -776,7 +776,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
                 
-  /api/v1/groups/{groupId}/posts:
+  /api/v1/groups/{id}/posts:
     post:
       tags:
         - Post Endpoints
@@ -860,22 +860,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /api/v1/groups/{groupId}/posts/{postId}:
+  /api/v1/posts/{id}:
     get:
       tags:
         - Post Endpoints
       summary: Gets a post
       description: Gets a post's details.
       parameters:
-        - name: groupId
-          in: path
-          description: ID of the group a post is made in
-          required: true
-          schema:
-            type: string
-            format: uuid
-            example: 5e91507e-5630-4efd-9fd4-799178870b10
-        - name: postId
+        - name: id
           in: path
           description: ID of the post
           required: true
@@ -887,7 +879,7 @@ paths:
         - BearerAuth: []
       responses:
         200:
-          description: Successfully created a post
+          description: Successfully retrieved a post
           content:
             application/json:
               schema:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, the issue being fixed (if applicable), motivation and context, and anything that we should look out for. -->
Remove groupId from post route for GET, PATCH, DELETE because it is not necessary. Fixed routes and removed groupId related tests for posts CRUD, all tests passed.

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added necessary tests (unit, integration, etc.) to cover the new functionality or fix.
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation to reflect changes (e.g., README, code comments).
- [x] I have removed any commented-out code, debug statements, or unnecessary console logs.
