### PR TITLE
✉️ feat: out-of-app invite endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "hono": "^4.6.14",
     "jest": "^29.7.0",
     "jsonwebtoken": "^9.0.2",
+    "nanoid": "^5.0.9",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "postgres": "^3.4.5",

--- a/backend/src/entities/groups/controller.ts
+++ b/backend/src/entities/groups/controller.ts
@@ -34,7 +34,6 @@ export class GroupControllerImpl implements GroupController {
   constructor(groupService: GroupService) {
     this.groupService = groupService;
   }
-
   async createGroup(ctx: Context): Promise<GROUP_API> {
     const createGroupImpl = async () => {
       const body = await ctx.req.json();

--- a/backend/src/entities/groups/route.ts
+++ b/backend/src/entities/groups/route.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { GroupController, GroupControllerImpl } from "./controller";
 import { GroupTransaction, GroupTransactionImpl } from "./transaction";
 import { GroupService, GroupServiceImpl } from "./service";
+import { invitationRoutes } from "../invitations/route";
 
 export const groupRoutes = (db: PostgresJsDatabase): Hono => {
   const group = new Hono();
@@ -17,6 +18,7 @@ export const groupRoutes = (db: PostgresJsDatabase): Hono => {
   group.delete("/:id", (ctx) => groupController.deleteGroup(ctx));
   group.get("/:id", (ctx) => groupController.getGroup(ctx));
   group.patch("/:id", (ctx) => groupController.updateGroup(ctx));
+  group.route("/", invitationRoutes(db));
 
   return group;
 };

--- a/backend/src/entities/groups/transaction.ts
+++ b/backend/src/entities/groups/transaction.ts
@@ -14,7 +14,6 @@ import { ForbiddenError, NotFoundError } from "../../utilities/errors/app-error"
 import { and, eq, sql, desc, between } from "drizzle-orm";
 import { Media, PostWithMedia } from "../posts/validator";
 
-
 export interface GroupTransaction {
   insertGroup(payload: CreateGroupPayload): Promise<Group | null>;
   deleteGroup(groupId: string, userId: string): Promise<void>;

--- a/backend/src/entities/groups/transaction.ts
+++ b/backend/src/entities/groups/transaction.ts
@@ -14,6 +14,7 @@ import { ForbiddenError, NotFoundError } from "../../utilities/errors/app-error"
 import { and, eq, sql, desc, between } from "drizzle-orm";
 import { Media, PostWithMedia } from "../posts/validator";
 
+
 export interface GroupTransaction {
   insertGroup(payload: CreateGroupPayload): Promise<Group | null>;
   deleteGroup(groupId: string, userId: string): Promise<void>;

--- a/backend/src/entities/groups/validator.ts
+++ b/backend/src/entities/groups/validator.ts
@@ -1,11 +1,17 @@
 import { MIN_LIMIT, NAME_MAX_LIMIT, TEXT_MAX_LIMIT } from "../../constants/database";
 import { convertToDate, validateCalendarParam, validateYearMonth } from "../../utilities/date";
 import { paginationSchema } from "../../utilities/pagination";
-import { groupsTable } from "../schema";
+import { groupsTable, invitationsTable, linksTable, membersTable } from "../schema";
 import z from "zod";
 
 export type CreateGroupPayload = typeof groupsTable.$inferInsert;
 export type Group = typeof groupsTable.$inferSelect;
+export type CreateLinkPayload = typeof linksTable.$inferInsert;
+export type CreateInvitePayload = typeof invitationsTable.$inferInsert;
+export type addMemberPayload = typeof membersTable.$inferInsert;
+export type GroupInvitation = {
+  token: string;
+};
 
 export const createGroupValidate = z
   .object({

--- a/backend/src/entities/invitations/controller.ts
+++ b/backend/src/entities/invitations/controller.ts
@@ -1,0 +1,39 @@
+import { Context } from "hono";
+import { Status } from "../../constants/http";
+import { CREATE_GROUP_INVITE, VERIFY_GROUP_INVITE } from "../../types/api/schemas/groups";
+import { handleAppError } from "../../utilities/errors/app-error";
+import { parseUUID } from "../../utilities/uuid";
+import { InvitationService } from "./service";
+
+export interface InvitationController {
+  createInviteToken(ctx: Context): Promise<CREATE_GROUP_INVITE>;
+  verifyInviteToken(ctx: Context): Promise<VERIFY_GROUP_INVITE>;
+}
+
+export class InvitationControllerImpl implements InvitationController {
+  private invitationService: InvitationService;
+
+  constructor(invitationService: InvitationService) {
+    this.invitationService = invitationService;
+  }
+  async verifyInviteToken(ctx: Context): Promise<VERIFY_GROUP_INVITE> {
+    const verifyInviteTokenImpl = async () => {
+      const userId = ctx.get("userId");
+      const token = ctx.req.param("token");
+      await this.invitationService.verifyInviteToken(token, userId);
+      return ctx.json({ message: "Successfully added to group" }, Status.OK);
+    };
+    return await handleAppError(verifyInviteTokenImpl)(ctx);
+  }
+
+  async createInviteToken(ctx: Context): Promise<CREATE_GROUP_INVITE> {
+    const createInviteTokenImpl = async () => {
+      const groupId = ctx.req.param("groupId");
+      const groupIdAsUUID = parseUUID(groupId);
+      const userId = ctx.get("userId");
+      const invite = await this.invitationService.createInviteToken(groupIdAsUUID, userId);
+      return ctx.json(invite, Status.OK);
+    };
+    return await handleAppError(createInviteTokenImpl)(ctx);
+  }
+}

--- a/backend/src/entities/invitations/route.ts
+++ b/backend/src/entities/invitations/route.ts
@@ -1,0 +1,19 @@
+import { Hono } from "hono";
+import { InvitationController, InvitationControllerImpl } from "./controller";
+import { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { InvitationTransaction, InvitationTransactionImpl } from "./transaction";
+import { InvitationService, InvitationServiceImpl } from "./service";
+
+export const invitationRoutes = (db: PostgresJsDatabase): Hono => {
+  const invite = new Hono();
+  const invitationTransaction: InvitationTransaction = new InvitationTransactionImpl(db);
+  const invitationService: InvitationService = new InvitationServiceImpl(invitationTransaction);
+  const invitationController: InvitationController = new InvitationControllerImpl(
+    invitationService,
+  );
+
+  invite.get("/:groupId/invites", (ctx) => invitationController.createInviteToken(ctx));
+  invite.put("/:token/verify", (ctx) => invitationController.verifyInviteToken(ctx));
+
+  return invite;
+};

--- a/backend/src/entities/invitations/service.ts
+++ b/backend/src/entities/invitations/service.ts
@@ -14,19 +14,19 @@ export interface InvitationService {
 }
 
 export class InvitationServiceImpl implements InvitationService {
-  private InvitationTransaction: InvitationTransaction;
+  private invitationTransaction: InvitationTransaction;
 
   constructor(InvitationTransaction: InvitationTransaction) {
-    this.InvitationTransaction = InvitationTransaction;
+    this.invitationTransaction = InvitationTransaction;
   }
 
   async verifyInviteToken(token: string, userId: string): Promise<void> {
     const verifyInviteTokenImpl = async () => {
-      const groupId = await this.InvitationTransaction.getGroupIdFromToken(token);
-      if (await this.InvitationTransaction.isManager(userId, groupId)) {
+      const groupId = await this.invitationTransaction.getGroupIdFromToken(token);
+      if (await this.invitationTransaction.isManager(userId, groupId)) {
         throw new NotFoundError("Group");
       }
-      if (!(await this.InvitationTransaction.verifyToken(token, groupId))) {
+      if (!(await this.invitationTransaction.verifyToken(token, groupId))) {
         throw new ForbiddenError("Token is invalid");
       }
       const payload: addMemberPayload = {
@@ -35,7 +35,7 @@ export class InvitationServiceImpl implements InvitationService {
         joinedAt: new Date(),
         role: "MEMBER",
       };
-      await this.InvitationTransaction.insertUserByInvitation(payload);
+      await this.invitationTransaction.insertUserByInvitation(payload);
     };
     return handleServiceError(verifyInviteTokenImpl)();
   }
@@ -45,10 +45,10 @@ export class InvitationServiceImpl implements InvitationService {
       const token = nanoid();
       const sevenDaysFromToday = new Date();
       sevenDaysFromToday.setDate(sevenDaysFromToday.getDate() + 7);
-      if (!(await this.InvitationTransaction.isManager(userId, groupId))) {
+      if (!(await this.invitationTransaction.isManager(userId, groupId))) {
         throw new NotFoundError("Group");
       }
-      const uploadedEncoding = await this.InvitationTransaction.insertInvitation(
+      const uploadedEncoding = await this.invitationTransaction.insertInvitation(
         {
           groupId: groupId,
           token: token,

--- a/backend/src/entities/invitations/service.ts
+++ b/backend/src/entities/invitations/service.ts
@@ -1,0 +1,68 @@
+import { nanoid } from "nanoid";
+import {
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+} from "../../utilities/errors/app-error";
+import { handleServiceError } from "../../utilities/errors/service-error";
+import { addMemberPayload, GroupInvitation } from "../groups/validator";
+import { InvitationTransaction } from "./transaction";
+
+export interface InvitationService {
+  createInviteToken(groupId: string, userId: string): Promise<GroupInvitation>;
+  verifyInviteToken(token: string, userId: string): Promise<void>;
+}
+
+export class InvitationServiceImpl implements InvitationService {
+  private InvitationTransaction: InvitationTransaction;
+
+  constructor(InvitationTransaction: InvitationTransaction) {
+    this.InvitationTransaction = InvitationTransaction;
+  }
+
+  async verifyInviteToken(token: string, userId: string): Promise<void> {
+    const verifyInviteTokenImpl = async () => {
+      const groupId = await this.InvitationTransaction.getGroupIdFromToken(token);
+
+      if (await this.InvitationTransaction.isManager(userId, groupId)) {
+        throw new NotFoundError("Group");
+      }
+      if (!(await this.InvitationTransaction.verifyToken(token, groupId))) {
+        throw new ForbiddenError("Token is invalid");
+      }
+      const payload: addMemberPayload = {
+        groupId: groupId,
+        userId: userId,
+        joinedAt: new Date(),
+        role: "MEMBER",
+      };
+      await this.InvitationTransaction.insertUserByInvitation(payload);
+    };
+    return handleServiceError(verifyInviteTokenImpl)();
+  }
+
+  async createInviteToken(groupId: string, userId: string): Promise<GroupInvitation> {
+    const createInviteTokenImpl = async () => {
+      const token = nanoid();
+      const sevenDaysFromToday = new Date();
+      sevenDaysFromToday.setDate(sevenDaysFromToday.getDate() + 7);
+      if (!(await this.InvitationTransaction.isManager(userId, groupId))) {
+        throw new NotFoundError("Group");
+      }
+      const uploadedEncoding = await this.InvitationTransaction.insertInvitation(
+        {
+          groupId: groupId,
+          token: token,
+          expiresAt: sevenDaysFromToday,
+          createdAt: new Date(),
+        },
+        userId,
+      );
+      if (!uploadedEncoding) {
+        throw new InternalServerError("Failed to create invitation token");
+      }
+      return uploadedEncoding;
+    };
+    return handleServiceError(createInviteTokenImpl)();
+  }
+}

--- a/backend/src/entities/invitations/service.ts
+++ b/backend/src/entities/invitations/service.ts
@@ -23,7 +23,6 @@ export class InvitationServiceImpl implements InvitationService {
   async verifyInviteToken(token: string, userId: string): Promise<void> {
     const verifyInviteTokenImpl = async () => {
       const groupId = await this.InvitationTransaction.getGroupIdFromToken(token);
-
       if (await this.InvitationTransaction.isManager(userId, groupId)) {
         throw new NotFoundError("Group");
       }

--- a/backend/src/entities/invitations/transaction.ts
+++ b/backend/src/entities/invitations/transaction.ts
@@ -42,10 +42,7 @@ export class InvitationTransactionImpl implements InvitationTransaction {
     return await this.db.transaction(async (tx) => {
       const match = and(eq(linksTable.token, token), eq(linksTable.groupId, groupId));
       const [query] = await tx.select().from(linksTable).where(match);
-      if (!query) {
-        return false;
-      }
-      if (query.expiresAt < new Date()) {
+      if (!query || query.expiresAt < new Date()) {
         return false;
       }
       return true;

--- a/backend/src/entities/invitations/transaction.ts
+++ b/backend/src/entities/invitations/transaction.ts
@@ -1,0 +1,101 @@
+import { and, eq } from "drizzle-orm";
+import { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { InternalServerError, NotFoundError } from "../../utilities/errors/app-error";
+import {
+  addMemberPayload,
+  CreateInvitePayload,
+  CreateLinkPayload,
+  GroupInvitation,
+} from "../groups/validator";
+import { linksTable, membersTable, invitationsTable } from "../schema";
+
+export interface InvitationTransaction {
+  /**
+   * @param userId the id of the user getting invited
+   * @param groupId the id of the group the user is getting invited to
+   */
+  isManager(userId: string, groupId: string): Promise<boolean>;
+  verifyToken(token: string, groupId: string): Promise<boolean>;
+  insertUserByInvitation(payload: addMemberPayload): Promise<void>;
+  insertInvitation(payload: CreateLinkPayload, userId: string): Promise<GroupInvitation | null>;
+  getGroupIdFromToken(token: string): Promise<string>;
+}
+export class InvitationTransactionImpl implements InvitationTransaction {
+  private db: PostgresJsDatabase;
+
+  constructor(db: PostgresJsDatabase) {
+    this.db = db;
+  }
+  async getGroupIdFromToken(token: string): Promise<string> {
+    return await this.db.transaction(async (tx) => {
+      const [result] = await tx
+        .select({ groupId: linksTable.groupId })
+        .from(linksTable)
+        .where(eq(linksTable.token, token));
+      if (!result) {
+        throw new NotFoundError("Invalid Token");
+      }
+      return result.groupId;
+    });
+  }
+  async verifyToken(token: string, groupId: string): Promise<boolean> {
+    return await this.db.transaction(async (tx) => {
+      const match = and(eq(linksTable.token, token), eq(linksTable.groupId, groupId));
+      const [query] = await tx.select().from(linksTable).where(match);
+      if (!query) {
+        return false;
+      }
+      if (query.expiresAt < new Date()) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  async insertUserByInvitation(payload: addMemberPayload): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      const [insert] = await tx.insert(membersTable).values(payload).returning();
+      if (!insert) {
+        throw new InternalServerError("Error adding user to the group");
+      }
+    });
+  }
+
+  async isManager(userId: string, groupId: string): Promise<boolean> {
+    const managerTx = await this.db.transaction(async (tx) => {
+      const [manager] = await tx
+        .select()
+        .from(membersTable)
+        .where(and(eq(membersTable.userId, userId), eq(membersTable.groupId, groupId)));
+      if (!manager) {
+        return false;
+      } else {
+        return manager.role === "MANAGER";
+      }
+    });
+    return managerTx;
+  }
+
+  async insertInvitation(
+    payload: CreateLinkPayload,
+    userId: string,
+  ): Promise<GroupInvitation | null> {
+    const createdInvitation = await this.db.transaction(async (tx) => {
+      const [link] = await tx.insert(linksTable).values(payload).returning();
+      if (!link) {
+        return null;
+      }
+      const newInviteEntry: CreateInvitePayload = {
+        groupId: link.groupId,
+        recipientId: userId,
+        invitationLinkId: link.id,
+      };
+      const [invite] = await tx.insert(invitationsTable).values(newInviteEntry).returning();
+      if (!invite) {
+        return null;
+      }
+      return { token: link.token };
+    });
+    return createdInvitation;
+  }
+}

--- a/backend/src/tests/groups/group-add-member.test.ts
+++ b/backend/src/tests/groups/group-add-member.test.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { TestBuilder } from "../helpers/test-builder";
 import { startTestApp } from "../helpers/test-app";
 import { HTTPRequest, Status } from "../../constants/http";
-import { DEARLY_GROUP_ID, USER_ALICE_ID, USER_BOB_ID } from "../helpers/test-constants";
+import { DEARLY_GROUP_ID, USER_ALICE_ID, USER_BILL_ID, USER_BOB_ID } from "../helpers/test-constants";
 import { generateJWTFromID } from "../helpers/test-token";
 
 const addMemberToGroupInviteTest = () => {
@@ -40,10 +40,34 @@ const addMemberToGroupInviteTest = () => {
       route: `api/v1/groups/${token}/verify`,
       autoAuthorized: false,
       headers: {
-        Authorization: `Bearer ${generateJWTFromID(USER_BOB_ID)}`,
+        Authorization: `Bearer ${generateJWTFromID(USER_BILL_ID)}`,
       },
     });
     builder.assertStatusCode(Status.OK);
+  });
+
+  it("Should return 409 if the person being invited is already in the group", async () => {
+    testBuilder = await testBuilder.request({
+      app,
+      type: HTTPRequest.GET,
+      route: `/api/v1/groups/${DEARLY_GROUP_ID}/invites`,
+      autoAuthorized: false,
+      headers: {
+        Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
+      },
+    });
+
+    const token = testBuilder.getResponseBodyKey("token") as string;
+    const builder = await testBuilder.request({
+      app,
+      type: HTTPRequest.PUT,
+      route: `api/v1/groups/${token}/verify`,
+      autoAuthorized: false,
+      headers: {
+        Authorization: `Bearer ${generateJWTFromID(USER_BOB_ID)}`,
+      },
+    });
+    builder.assertStatusCode(Status.Conflict);
   });
 
   it("Should return 404 if the manager requests it", async () => {

--- a/backend/src/tests/groups/group-add-member.test.ts
+++ b/backend/src/tests/groups/group-add-member.test.ts
@@ -13,9 +13,21 @@ import { generateJWTFromID } from "../helpers/test-token";
 const addMemberToGroupInviteTest = () => {
   let app: Hono;
   let testBuilder = new TestBuilder();
+  let token: string;
 
   beforeAll(async () => {
     app = await startTestApp();
+    testBuilder = await testBuilder.request({
+      app,
+      type: HTTPRequest.GET,
+      route: `/api/v1/groups/${DEARLY_GROUP_ID}/invites`,
+      autoAuthorized: false,
+      headers: {
+        Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
+      },
+    });
+
+    token = testBuilder.getResponseBodyKey("token") as string;
   });
 
   it("Should return 403 for a unknown or invalid token", async () => {
@@ -28,17 +40,6 @@ const addMemberToGroupInviteTest = () => {
   });
 
   it("Should return 200 for a good token", async () => {
-    testBuilder = await testBuilder.request({
-      app,
-      type: HTTPRequest.GET,
-      route: `/api/v1/groups/${DEARLY_GROUP_ID}/invites`,
-      autoAuthorized: false,
-      headers: {
-        Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
-      },
-    });
-
-    const token = testBuilder.getResponseBodyKey("token") as string;
     const builder = await testBuilder.request({
       app,
       type: HTTPRequest.PUT,
@@ -52,17 +53,6 @@ const addMemberToGroupInviteTest = () => {
   });
 
   it("Should return 409 if the person being invited is already in the group", async () => {
-    testBuilder = await testBuilder.request({
-      app,
-      type: HTTPRequest.GET,
-      route: `/api/v1/groups/${DEARLY_GROUP_ID}/invites`,
-      autoAuthorized: false,
-      headers: {
-        Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
-      },
-    });
-
-    const token = testBuilder.getResponseBodyKey("token") as string;
     const builder = await testBuilder.request({
       app,
       type: HTTPRequest.PUT,
@@ -80,7 +70,7 @@ const addMemberToGroupInviteTest = () => {
     const builder = await testBuilder.request({
       app,
       type: HTTPRequest.PUT,
-      route: `api/v1/groups/verify`,
+      route: `api/v1/groups/${token}/verify`,
       autoAuthorized: false,
       headers: {
         Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,

--- a/backend/src/tests/groups/group-add-member.test.ts
+++ b/backend/src/tests/groups/group-add-member.test.ts
@@ -2,7 +2,12 @@ import { Hono } from "hono";
 import { TestBuilder } from "../helpers/test-builder";
 import { startTestApp } from "../helpers/test-app";
 import { HTTPRequest, Status } from "../../constants/http";
-import { DEARLY_GROUP_ID, USER_ALICE_ID, USER_BILL_ID, USER_BOB_ID } from "../helpers/test-constants";
+import {
+  DEARLY_GROUP_ID,
+  USER_ALICE_ID,
+  USER_BILL_ID,
+  USER_BOB_ID,
+} from "../helpers/test-constants";
 import { generateJWTFromID } from "../helpers/test-token";
 
 const addMemberToGroupInviteTest = () => {

--- a/backend/src/tests/groups/group-add-member.test.ts
+++ b/backend/src/tests/groups/group-add-member.test.ts
@@ -1,0 +1,64 @@
+import { Hono } from "hono";
+import { TestBuilder } from "../helpers/test-builder";
+import { startTestApp } from "../helpers/test-app";
+import { HTTPRequest, Status } from "../../constants/http";
+import { DEARLY_GROUP_ID, USER_ALICE_ID, USER_BOB_ID } from "../helpers/test-constants";
+import { generateJWTFromID } from "../helpers/test-token";
+
+const addMemberToGroupInviteTest = () => {
+  let app: Hono;
+  let testBuilder = new TestBuilder();
+
+  beforeAll(async () => {
+    app = await startTestApp();
+  });
+
+  it("Should return 403 for a unknown or invalid token", async () => {
+    testBuilder = await testBuilder.request({
+      app,
+      type: HTTPRequest.PUT,
+      route: `api/v1/groups/notcorrecttoken/verify`,
+    });
+    testBuilder.assertStatusCode(Status.NotFound);
+  });
+
+  it("Should return 200 for a good token", async () => {
+    testBuilder = await testBuilder.request({
+      app,
+      type: HTTPRequest.GET,
+      route: `/api/v1/groups/${DEARLY_GROUP_ID}/invites`,
+      autoAuthorized: false,
+      headers: {
+        Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
+      },
+    });
+
+    const token = testBuilder.getResponseBodyKey("token") as string;
+    const builder = await testBuilder.request({
+      app,
+      type: HTTPRequest.PUT,
+      route: `api/v1/groups/${token}/verify`,
+      autoAuthorized: false,
+      headers: {
+        Authorization: `Bearer ${generateJWTFromID(USER_BOB_ID)}`,
+      },
+    });
+    builder.assertStatusCode(Status.OK);
+  });
+
+  it("Should return 404 if the manager requests it", async () => {
+    // Get the token as group manager
+    const builder = await testBuilder.request({
+      app,
+      type: HTTPRequest.PUT,
+      route: `api/v1/groups/verify`,
+      autoAuthorized: false,
+      headers: {
+        Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
+      },
+    });
+    builder.assertStatusCode(Status.NotFound);
+  });
+};
+
+describe("PUT /groups/{token}/verify", addMemberToGroupInviteTest);

--- a/backend/src/tests/groups/group-invite.test.ts
+++ b/backend/src/tests/groups/group-invite.test.ts
@@ -1,0 +1,81 @@
+import { Hono } from "hono";
+import { TestBuilder } from "../helpers/test-builder";
+import { startTestApp } from "../helpers/test-app";
+import { HTTPRequest, Status } from "../../constants/http";
+import { USER_ALICE_ID, USER_BOB_ID } from "../helpers/test-constants";
+import { generateJWTFromID } from "../helpers/test-token";
+
+const getGroupInviteTest = () => {
+  let app: Hono;
+  let groupId: string;
+  const jwt = generateJWTFromID(USER_ALICE_ID);
+  const testBuilder = new TestBuilder();
+  const insertExampleGroup = async (app: Hono) => {
+    const builder = await testBuilder.request({
+      app,
+      type: HTTPRequest.POST,
+      route: "/api/v1/groups",
+      requestBody: {
+        name: "exampleGroup",
+        description: "exampleDesc",
+      },
+      autoAuthorized: false,
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+      },
+    });
+    groupId = builder.getResponseId();
+  };
+
+  beforeAll(async () => {
+    app = await startTestApp();
+    await insertExampleGroup(app);
+  });
+
+  it("should return 200 if valid groupId", async () => {
+    const builder = await testBuilder.request({
+      app,
+      type: HTTPRequest.GET,
+      route: `/api/v1/groups/${groupId}/invites`,
+      autoAuthorized: false,
+      headers: {
+        Authorization: `Bearer ${generateJWTFromID(USER_ALICE_ID)}`,
+      },
+    });
+    builder.assertStatusCode(Status.OK);
+    builder.assertFieldExists("token");
+  });
+
+  it("should return 404 if the user who requests the token is not the manager", async () => {
+    const builder = await testBuilder.request({
+      app,
+      type: HTTPRequest.GET,
+      route: `/api/v1/groups/${groupId}/invites`,
+      autoAuthorized: false,
+      headers: {
+        Authorization: `Bearer ${generateJWTFromID(USER_BOB_ID)}`,
+      },
+    });
+    builder.assertStatusCode(Status.NotFound);
+  });
+
+  it("should return 400 if malformed", async () => {
+    const builder = await testBuilder.request({
+      app,
+      type: HTTPRequest.GET,
+      route: `/api/v1/groups/sajldkjsakldjlask/invites`,
+    });
+    builder.assertStatusCode(Status.BadRequest);
+  });
+
+  it("should 404 if the group doesn't exist", async () => {
+    const builder = await testBuilder.request({
+      app,
+      type: HTTPRequest.GET,
+      route: `/api/v1/groups/${USER_BOB_ID}/invites`,
+    });
+    builder.assertStatusCode(Status.NotFound);
+  });
+};
+
+describe("GET /groups/{id}/invites", getGroupInviteTest);

--- a/backend/src/tests/helpers/test-builder.ts
+++ b/backend/src/tests/helpers/test-builder.ts
@@ -97,7 +97,6 @@ export class TestBuilder {
     return resultHeaders;
   }
 
-
   getResponseBodyKey(key: string): unknown {
     if (this.type === HTTPRequest.DELETE) {
       throw new Error("Cannot retrieve id from DELETE request");

--- a/backend/src/tests/helpers/test-builder.ts
+++ b/backend/src/tests/helpers/test-builder.ts
@@ -97,6 +97,20 @@ export class TestBuilder {
     return resultHeaders;
   }
 
+
+  getResponseBodyKey(key: string): unknown {
+    if (this.type === HTTPRequest.DELETE) {
+      throw new Error("Cannot retrieve id from DELETE request");
+    }
+    if (!this.body) {
+      throw new Error("Response is not defined.");
+    }
+    if (!this.body[key]) {
+      throw new Error(`${key} does not exist in the response body.`);
+    }
+    return this.body[key];
+  }
+
   /**
    * Get the response ID (for non-DELETE requests)
    */

--- a/backend/src/types/api/schemas/groups.ts
+++ b/backend/src/types/api/schemas/groups.ts
@@ -1,8 +1,19 @@
 import { TypedResponse } from "hono";
 import { components, paths } from "../../../gen/openapi";
+import { API_ERROR } from "./error";
 
 export type GROUP_API = TypedResponse<
   | paths["/api/v1/groups"]["post"]["responses"]["201"]["content"]["application/json"]
   | components["schemas"]["Error"]
   | components["schemas"]["ValidationError"]
+>;
+
+export type CREATE_GROUP_INVITE = TypedResponse<
+  | paths["/api/v1/groups/{groupId}/invites"]["get"]["responses"]["200"]["content"]["application/json"]
+  | API_ERROR
+>;
+
+export type VERIFY_GROUP_INVITE = TypedResponse<
+  | paths["/api/v1/groups/{groupId}/{token}/verify"]["put"]["responses"]["200"]["content"]["application/json"]
+  | API_ERROR
 >;

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -4,6 +4,7 @@
 - [Working on Controllers and Routes](#working-on-controllers-and-routes)
 - [Error Handling](#error-handling)
 - [Write Integration Tests with Test Builder](#write-integration-tests-with-test-builder)
+- [Deep-Linking](#deep-linking)
 
 ## **Working on Controllers and Routes**
 
@@ -366,4 +367,15 @@ Since we are calling `debug`, it will show in the console:
 
 ```
 Response Body:  {"message":"Validation failed","errors":[{"path":"lastName","message":"Required"}]}
+```
+
+
+## **Deep linking**
+
+### IOS 
+Currently the dearly's focus is on IOS development, and therefore will support universal linking. 
+
+simulate an app deep-link in development from the command line:
+```bash 
+bunx uri-scheme open exp://127.0.0.1:8081/ --ios
 ```

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -376,6 +376,7 @@ Response Body:  {"message":"Validation failed","errors":[{"path":"lastName","mes
 Currently the dearly's focus is on IOS development, and therefore will support universal linking. 
 
 simulate an app deep-link in development from the command line:
+
 ```bash 
 bunx uri-scheme open exp://127.0.0.1:8081/ --ios
 ```

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -237,14 +237,76 @@ components:
           description: The type of the media (e.g., photo, video).
 
 paths:
-  /api/v1/groups/{id}/invites:
+  /api/v1/groups/{token}/verify:
+    put:
+      tags:
+        - Group Endpoints 
+      summary: Adds the user into the group 
+      description: Adds the user with the valid token into the group. 
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: token 
+          in: path 
+          description: token to be invited to the group 
+          required: true
+          schema:
+            type: string 
+      responses:
+        200:
+          description: Successfully added to group 
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Successfully added to group"
+        400:
+          description: Malformed request
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Error"
+                  - $ref: "#/components/schemas/ValidationError"
+        401:
+          description: Unauthorized due to invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        404:
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      
+  /api/v1/groups/{groupId}/invites:
     get:
       tags:
         - Group Endpoints
-      summary: Get the token for the out of app invite
+      summary: Gets an invite token
       description: Creates a token that can be used for deeplinking on the client side.
       security:
         - BearerAuth: []
+      parameters:
+        - name: groupId
+          in: path
+          description: ID of the group
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 5e91507e-5630-4efd-9fd4-799178870b10
       responses:
         200:
           description: Successfully created the unique access token
@@ -255,8 +317,8 @@ paths:
                 properties:
                   token:
                     type: string
-                    format: base64
-                    example: ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
+                required:
+                  - token
         400:
           description: Malformed request
           content:
@@ -1110,7 +1172,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-
   /api/v1/groups/{id}/posts:
     post:
       tags:
@@ -1384,7 +1445,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-
   /api/v1/groups/{id}/members/{userId}:
     post:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -237,6 +237,52 @@ components:
           description: The type of the media (e.g., photo, video).
 
 paths:
+  /api/v1/groups/{id}/invites:
+    get:
+      tags:
+        - Group Endpoints
+      summary: Get the token for the out of app invite
+      description: Creates a token that can be used for deeplinking on the client side.
+      security:
+        - BearerAuth: []
+      responses:
+        200:
+          description: Successfully created the unique access token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    format: base64
+                    example: ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
+        400:
+          description: Malformed request
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Error"
+                  - $ref: "#/components/schemas/ValidationError"
+        401:
+          description: Unauthorized due to invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        404:
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/v1/groups:
     post:
       tags:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -84,3 +84,10 @@ tasks:
     desc: "Generate Schema from OpenAPI Specification"
     cmds:
       - cd backend && bun run gen
+
+  clean:
+    desc: "Clean up temporary files"
+    cmds:
+      - rm -rf node_modules bun.lockb package-lock.json
+      - cd backend && rm -rf node_modules bun.lockb package-lock.json gen
+      - cd frontend && rm -rf node_modules bun.lockb package-lock.json .expo gen


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, the issue being fixed (if applicable), motivation and context, and anything that we should look out for. -->

- Created an endpoint where valid manager of a group can fetch a token to share to other users to invite them. 
- Created test cases that cover most (if not all edge cases) 
- Things to note:
- Since generating a new token on every endpoint is a bit tricky, I amended the endpoint to also take in the groupId since it's impossible for different tokens to be decoded and hash to the same value.
- the crypto module is really weird, unsure why it silently fails on hono app request.

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added necessary tests (unit, integration, etc.) to cover the new functionality or fix.
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation to reflect changes (e.g., README, code comments).
- [x] I have removed any commented-out code, debug statements, or unnecessary console logs.
