### PR TITLE
🔔 feat: endpoint for member to turn on/off group notification 

### DIFF
--- a/backend/src/entities/groups/transaction.ts
+++ b/backend/src/entities/groups/transaction.ts
@@ -165,9 +165,20 @@ export class GroupTransactionImpl implements GroupTransaction {
         managerId: groupsTable.managerId,
         description: groupsTable.description,
         name: groupsTable.name,
+        notificationEnabled: membersTable.notificationsEnabled,
       })
       .from(groupsTable)
-      .groupBy(groupsTable.id, groupsTable.managerId, groupsTable.description, groupsTable.name)
+      .innerJoin(
+        membersTable,
+        and(eq(membersTable.groupId, groupId), eq(membersTable.userId, userId)),
+      )
+      .groupBy(
+        groupsTable.id,
+        groupsTable.managerId,
+        groupsTable.description,
+        groupsTable.name,
+        membersTable.notificationsEnabled,
+      )
       .where(eq(groupsTable.id, groupId));
     if (!result) return null;
     return result;

--- a/backend/src/entities/members/controller.ts
+++ b/backend/src/entities/members/controller.ts
@@ -3,7 +3,7 @@ import { MemberService } from "./service";
 import { parseUUID } from "../../utilities/uuid";
 import { handleAppError } from "../../utilities/errors/app-error";
 import { Status } from "../../constants/http";
-import { ADD_MEMBER, DEL_MEMBER, MEMBERS_API } from "../../types/api/routes/members";
+import { ADD_MEMBER, DEL_MEMBER, MEMBERS_API, NOTIFICATION } from "../../types/api/routes/members";
 import { MemberRole } from "../../constants/database";
 import { paginationSchema } from "../../utilities/pagination";
 
@@ -11,7 +11,7 @@ export interface MemberController {
   addMember(ctx: Context): Promise<ADD_MEMBER>;
   deleteMember(ctx: Context): Promise<DEL_MEMBER>;
   getMembers(ctx: Context): Promise<MEMBERS_API>;
-  toggleNotification(ctx: Context): Promise<Response>;
+  toggleNotification(ctx: Context): Promise<NOTIFICATION>;
 }
 
 export class MemberControllerImpl implements MemberController {
@@ -66,7 +66,7 @@ export class MemberControllerImpl implements MemberController {
     return await handleAppError(getMembers)(ctx);
   }
 
-  async toggleNotification(ctx: Context): Promise<Response> {
+  async toggleNotification(ctx: Context): Promise<NOTIFICATION> {
     const toggleNotificationImpl = async () => {
       const userId = ctx.get("userId");
       const groupId = parseUUID(ctx.req.param("id"));

--- a/backend/src/entities/members/controller.ts
+++ b/backend/src/entities/members/controller.ts
@@ -11,6 +11,7 @@ export interface MemberController {
   addMember(ctx: Context): Promise<ADD_MEMBER>;
   deleteMember(ctx: Context): Promise<DEL_MEMBER>;
   getMembers(ctx: Context): Promise<MEMBERS_API>;
+  toggleNotification(ctx: Context): Promise<Response>;
 }
 
 export class MemberControllerImpl implements MemberController {
@@ -63,5 +64,16 @@ export class MemberControllerImpl implements MemberController {
     };
 
     return await handleAppError(getMembers)(ctx);
+  }
+
+  async toggleNotification(ctx: Context): Promise<Response> {
+    const toggleNotificationImpl = async () => {
+      const userId = ctx.get("userId");
+      const groupId = parseUUID(ctx.req.param("id"));
+      const notificationOn = await this.memberService.toggleNotification({ userId, id: groupId });
+      const message = notificationOn ? "turn on" : "turn off";
+      return ctx.json({ message: `Successfully ${message} notification for group` }, Status.OK);
+    };
+    return await handleAppError(toggleNotificationImpl)(ctx);
   }
 }

--- a/backend/src/entities/members/route.ts
+++ b/backend/src/entities/members/route.ts
@@ -14,6 +14,7 @@ export const memberRoutes = (db: PostgresJsDatabase): Hono => {
   member.post("/:userId", (ctx) => memberController.addMember(ctx));
   member.delete("/:userId", (ctx) => memberController.deleteMember(ctx));
   member.get("/", (ctx) => memberController.getMembers(ctx));
+  member.patch("/notifications", (ctx) => memberController.toggleNotification(ctx));
 
   return member;
 };

--- a/backend/src/entities/members/service.ts
+++ b/backend/src/entities/members/service.ts
@@ -51,10 +51,8 @@ export class MemberServiceImpl implements MemberService {
 
   async toggleNotification(payload: IDPayload): Promise<boolean> {
     const toggleNotificationImpl = async () => {
-      const notificationEnabled = await this.memberTransaction.toggleNotification(payload);
-      return notificationEnabled;
+      return await this.memberTransaction.toggleNotification(payload);
     };
-
     return handleServiceError(toggleNotificationImpl)();
   }
 }

--- a/backend/src/entities/members/service.ts
+++ b/backend/src/entities/members/service.ts
@@ -1,5 +1,6 @@
 import { AddMemberPayload, Member } from "../../types/api/internal/members";
 import { Pagination, SearchedUser } from "../../types/api/internal/users";
+import { IDPayload } from "../../types/id";
 import { InternalServerError, NotFoundError } from "../../utilities/errors/app-error";
 import { handleServiceError } from "../../utilities/errors/service-error";
 import { MemberTransaction } from "./transaction";
@@ -8,6 +9,7 @@ export interface MemberService {
   addMember(payload: AddMemberPayload): Promise<Member>;
   deleteMember(clientId: string, userId: string, groupId: string): Promise<void>;
   getMembers(groupId: string, payload: Pagination): Promise<SearchedUser[]>;
+  toggleNotification(payload: IDPayload): Promise<boolean>;
 }
 
 export class MemberServiceImpl implements MemberService {
@@ -45,5 +47,14 @@ export class MemberServiceImpl implements MemberService {
     };
 
     return handleServiceError(getMembersImpl)();
+  }
+
+  async toggleNotification(payload: IDPayload): Promise<boolean> {
+    const toggleNotificationImpl = async () => {
+      const notificationEnabled = await this.memberTransaction.toggleNotification(payload);
+      return notificationEnabled;
+    };
+
+    return handleServiceError(toggleNotificationImpl)();
   }
 }

--- a/backend/src/entities/users/transaction.ts
+++ b/backend/src/entities/users/transaction.ts
@@ -56,7 +56,6 @@ export class UserTransactionImpl implements UserTransaction {
         username: payload.username,
         mode: payload.mode,
         profilePhoto: payload.profilePhoto,
-        notificationsEnabled: payload.notificationsEnabled,
       })
       .where(eq(usersTable.id, id))
       .returning();
@@ -129,6 +128,7 @@ export class UserTransactionImpl implements UserTransaction {
         name: groupsTable.name,
         description: groupsTable.description,
         managerId: groupsTable.managerId,
+        notificationEnabled: membersTable.notificationsEnabled,
       })
       .from(groupsTable)
       .innerJoin(

--- a/backend/src/tests/groups/get.test.ts
+++ b/backend/src/tests/groups/get.test.ts
@@ -70,6 +70,7 @@ describe("GET /groups/:id", () => {
         ...goodRequestBody,
         id,
         managerId: USER_ALICE_ID,
+        notificationEnabled: true,
       });
   });
 
@@ -88,6 +89,7 @@ describe("GET /groups/:id", () => {
       .assertStatusCode(Status.OK)
       .assertBody({
         ...GROUP_MOCK[0],
+        notificationEnabled: true,
       });
   });
 

--- a/backend/src/tests/members/notification.test.ts
+++ b/backend/src/tests/members/notification.test.ts
@@ -1,0 +1,101 @@
+import {
+  USER_ANA_ID,
+  USER_BOB_ID,
+  USER_ALICE_ID,
+  INVALID_ID_ARRAY,
+  POST_ID,
+  DEARLY_GROUP_ID,
+} from "../helpers/test-constants";
+import { Hono } from "hono";
+import { startTestApp } from "../helpers/test-app";
+import { TestBuilder } from "../helpers/test-builder";
+import { generateJWTFromID, generateUUID } from "../helpers/test-token";
+import { HTTPRequest, Status } from "../../constants/http";
+
+describe("PATCH /groups/:id/members/notifications", () => {
+  let app: Hono;
+  const testBuilder = new TestBuilder();
+
+  const ALICE_JWT = generateJWTFromID(USER_ALICE_ID);
+  const ANA_JWT = generateJWTFromID(USER_ANA_ID);
+
+  beforeAll(async () => {
+    app = await startTestApp();
+  });
+
+  it("should return 200 if notification is toggled successfully for member", async () => {
+    // Alice has notification for group turned on by default, so it should be turned off
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.PATCH,
+        route: `/api/v1/groups/${DEARLY_GROUP_ID}/members/notifications`,
+        autoAuthorized: false,
+        headers: {
+          Authorization: `Bearer ${ALICE_JWT}`,
+        },
+      })
+    )
+      .assertStatusCode(Status.OK)
+      .assertMessage("Successfully turn off notification for group");
+
+    // now notification is turned off, should turn on again
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.PATCH,
+        route: `/api/v1/groups/${DEARLY_GROUP_ID}/members/notifications`,
+        autoAuthorized: false,
+        headers: {
+          Authorization: `Bearer ${ALICE_JWT}`,
+        },
+      })
+    )
+      .assertStatusCode(Status.OK)
+      .assertMessage("Successfully turn on notification for group");
+  });
+
+  it("should return 403 if post exists but user not in group", async () => {
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.PATCH,
+        route: `/api/v1/groups/${DEARLY_GROUP_ID}/members/notifications`,
+        autoAuthorized: false,
+        headers: {
+          Authorization: `Bearer ${ANA_JWT}`,
+        },
+      })
+    ).assertStatusCode(Status.Forbidden);
+  });
+
+  it("should return 404 if post not found", async () => {
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.PATCH,
+        route: `/api/v1/groups/${generateUUID()}/members/notifications`,
+        autoAuthorized: false,
+        headers: {
+          Authorization: `Bearer ${ALICE_JWT}`,
+        },
+      })
+    )
+      .assertStatusCode(Status.NotFound)
+      .assertError("Group does not exist.");
+  });
+
+  it.each(
+    INVALID_ID_ARRAY.map((id) => [id === null ? "null" : id === undefined ? "undefined" : id, id]),
+  )("should return 400 if invalid ID %s", async (id) => {
+    (
+      await testBuilder.request({
+        app,
+        type: HTTPRequest.PATCH,
+        route: `/api/v1/groups/${id}/members/notifications`,
+      })
+    )
+      .assertStatusCode(Status.BadRequest)
+      .assertError("Invalid ID format");
+  });
+});

--- a/backend/src/tests/members/notification.test.ts
+++ b/backend/src/tests/members/notification.test.ts
@@ -1,9 +1,7 @@
 import {
   USER_ANA_ID,
-  USER_BOB_ID,
   USER_ALICE_ID,
   INVALID_ID_ARRAY,
-  POST_ID,
   DEARLY_GROUP_ID,
 } from "../helpers/test-constants";
 import { Hono } from "hono";

--- a/backend/src/tests/users/groups.test.ts
+++ b/backend/src/tests/users/groups.test.ts
@@ -20,6 +20,16 @@ describe("GET /users/groups", () => {
     app = await startTestApp();
   });
 
+  const ANOTHER_GROUP_WITH_NOTIFICATION = {
+    ...ANOTHER_GROUP,
+    notificationEnabled: true,
+  };
+
+  const DEARLY_GROUP_WITH_NOTIFICATION = {
+    ...DEARLY_GROUP,
+    notificationEnabled: true,
+  };
+
   it("should return 200 if user not found", async () => {
     (
       await testBuilder.request({
@@ -41,10 +51,10 @@ describe("GET /users/groups", () => {
   });
 
   it.each([
-    [USER_ANA_ID, [ANOTHER_GROUP]],
-    [USER_BOB_ID, [DEARLY_GROUP]],
+    [USER_ANA_ID, [ANOTHER_GROUP_WITH_NOTIFICATION]],
+    [USER_BOB_ID, [DEARLY_GROUP_WITH_NOTIFICATION]],
     [USER_BILL_ID, []],
-    [USER_ALICE_ID, [DEARLY_GROUP, ANOTHER_GROUP]],
+    [USER_ALICE_ID, [DEARLY_GROUP_WITH_NOTIFICATION, ANOTHER_GROUP_WITH_NOTIFICATION]],
   ])("should return 200 if for user with ID %s", async (id, expectedGroups) => {
     (
       await testBuilder.request({
@@ -62,10 +72,10 @@ describe("GET /users/groups", () => {
   });
 
   it.each([
-    ["1", "1", [DEARLY_GROUP]],
-    ["1", "2", [ANOTHER_GROUP]],
+    ["1", "1", [DEARLY_GROUP_WITH_NOTIFICATION]],
+    ["1", "2", [ANOTHER_GROUP_WITH_NOTIFICATION]],
     ["1", "3", []],
-    ["2", "1", [DEARLY_GROUP, ANOTHER_GROUP]],
+    ["2", "1", [DEARLY_GROUP_WITH_NOTIFICATION, ANOTHER_GROUP_WITH_NOTIFICATION]],
     ["2", "2", []],
   ])("should return 200 with limit %s and page %s", async (limit, page, expectedBody) => {
     (

--- a/backend/src/types/api/internal/posts.ts
+++ b/backend/src/types/api/internal/posts.ts
@@ -20,3 +20,5 @@ export type PostWithMedia = Post & {
 export type PostWithMediaURL = Post & {
   media: MediaWithURL[];
 };
+
+export { Media };

--- a/backend/src/types/api/routes/members.ts
+++ b/backend/src/types/api/routes/members.ts
@@ -16,3 +16,8 @@ export type MEMBERS_API = TypedResponse<
   | paths["/api/v1/groups/{id}/members"]["get"]["responses"]["200"]["content"]["application/json"]
   | API_ERROR
 >;
+
+export type NOTIFICATION = TypedResponse<
+  | paths["/api/v1/groups/{id}/members/notifications"]["patch"]["responses"]["200"]["content"]["application/json"]
+  | API_ERROR
+>;

--- a/frontend/api/member.ts
+++ b/frontend/api/member.ts
@@ -39,3 +39,17 @@ export const getAllMembers = async (
   };
   return authWrapper<GroupMembers>()(req);
 };
+
+export const toggleNotification = async (id: string): Promise<void> => {
+  const req = async (token: string): Promise<void> => {
+    await fetchClient.PATCH("/api/v1/groups/{id}/members/notifications", {
+      headers: getHeaders(token),
+      params: {
+        path: {
+          id,
+        },
+      },
+    });
+  };
+  return authWrapper<void>()(req);
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1359,6 +1359,67 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /api/v1/groups/{id}/members/notifications:
+    patch:
+      tags:
+        - Member Endpoints
+      summary: Toggle member's notification for a group
+      description: Turn on or off notification for a group
+      parameters:
+        - name: id
+          in: path
+          description: ID of the group
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 5e91507e-5630-4efd-9fd4-799178870b10
+      security:
+        - BearerAuth: []
+      responses:
+        200:
+          description: Successfully turn on or off group notification
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Successfully turn on notification for group"
+        400:
+          description: Malformed request
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Error"
+                  - $ref: "#/components/schemas/ValidationError"
+        401:
+          description: Unauthorized due to invalid JWT
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        403:
+          description: Forbidden since user is not member of the group
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        404:
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /api/v1/groups/{id}/posts:
     post:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -142,6 +142,10 @@ components:
           type: string
           description: A description of the group.
           nullable: true
+        notificationEnabled:
+          type: boolean
+          example: true
+          description: Return true if user has notification for group turned off.
         id:
           type: string
           format: uuid
@@ -530,25 +534,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      description: The name of the group.
-                    description:
-                      type: string
-                      description: A description of the group.
-                      nullable: true
-                    id:
-                      type: string
-                      format: uuid
-                      example: 5e91507e-5630-4efd-9fd4-799178870b10
-                      description: A unique identifier for the group.
-                    managerId:
-                      type: string
-                      format: uuid
-                      example: 5e91507e-5630-4efd-9fd4-799178870b10
-                      description: A unique identifier of the group manager.
+                  $ref: "#/components/schemas/Group"
         400:
           description: Malformed query params
           content:
@@ -894,30 +880,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: The name of the group.
-                  description:
-                    type: string
-                    description: A description of the group.
-                    nullable: true
-                  id:
-                    type: string
-                    format: uuid
-                    example: 5e91507e-5630-4efd-9fd4-799178870b10
-                    description: A unique identifier for the group.
-                  managerId:
-                    type: string
-                    format: uuid
-                    example: 5e91507e-5630-4efd-9fd4-799178870b10
-                    description: A unique identifier of the group manager.
-                required:
-                  - name
-                  - id
-                  - managerId
-                  - description
+                $ref: "#/components/schemas/Group"
         400:
           description: Malformed request
           content:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, the issue being fixed (if applicable), motivation and context, and anything that we should look out for. -->
Add endpoint where users can turn on and off notification for a group.

### Tests are added to ensure: 
- successfully toggle the previous state 
- throw forbidden error if user is not member of a group
- throw not found error if group not found
- throw error if the param for groupId is not a UUID

## Checklist:

- [x] I have performed a self-review of my code.
- [x] I have added necessary tests (unit, integration, etc.) to cover the new functionality or fix.
- [x] All new and existing tests pass locally.
- [x] I have updated the documentation to reflect changes (e.g., README, code comments).
- [x] I have removed any commented-out code, debug statements, or unnecessary console logs.
